### PR TITLE
Updated to go release 2010-10-13

### DIFF
--- a/http/fs.go
+++ b/http/fs.go
@@ -140,8 +140,8 @@ func serveFileInternal(c *Conn, r *Request, name string, redirect bool) {
 		c.SetHeader("Content-Type", ctype)
 	} else {
 		// read first chunk to decide between utf-8 text and binary
-		var buf [1024]byte
-		n, _ := io.ReadFull(f, &buf)
+		var buf []byte = make([]byte, 1024)
+		n, _ := io.ReadFull(f, buf)
 		b := buf[0:n]
 		if isText(b) {
 			c.SetHeader("Content-Type", "text-plain; charset=utf-8")

--- a/http/server.go
+++ b/http/server.go
@@ -124,11 +124,11 @@ func (c *Conn) SetHeader(hdr, val string) { c.header[CanonicalHeaderKey(hdr)] = 
 // send error codes.
 func (c *Conn) WriteHeader(code int) {
 	if c.hijacked {
-		log.Stderr("http: Conn.WriteHeader on hijacked connection")
+		log.Println("http: Conn.WriteHeader on hijacked connection")
 		return
 	}
 	if c.wroteHeader {
-		log.Stderr("http: multiple Conn.WriteHeader calls")
+		log.Println("http: multiple Conn.WriteHeader calls")
 		return
 	}
 	c.wroteHeader = true
@@ -158,7 +158,7 @@ func (c *Conn) WriteHeader(code int) {
 // before writing the data.
 func (c *Conn) Write(data []byte) (n int, err os.Error) {
 	if c.hijacked {
-		log.Stderr("http: Conn.Write on hijacked connection")
+		log.Println("http: Conn.Write on hijacked connection")
 		return 0, ErrHijacked
 	}
 	if !c.wroteHeader {

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func parseFlags() {
 	for _, n := range req {
 		f := flag.Lookup(n.(string))
 		if f.DefValue == f.Value.String() {
-			log.Stderrf("Required flag not set: -%s", f.Name)
+			log.Printf("Required flag not set: -%s", f.Name)
 			flag.Usage()
 			os.Exit(1)
 		}
@@ -31,16 +31,16 @@ func main() {
 	// testBencode()
 	// testUPnP()
 	parseFlags()
-	log.Stderr("Starting.")
+	log.Println("Starting.")
 	ts, err := taipei.NewTorrentSession(torrent)
 	if err != nil {
-		log.Stderr("Could not create torrent session.", err)
+		log.Println("Could not create torrent session.", err)
 		return
 	}
 	err = ts.DoTorrent()
 	if err != nil {
-		log.Stderr("Failed: ", err)
+		log.Println("Failed: ", err)
 	} else {
-		log.Stderr("Done")
+		log.Println("Done")
 	}
 }

--- a/taipei/metainfo.go
+++ b/taipei/metainfo.go
@@ -138,7 +138,7 @@ func getTrackerInfo(url string) (tr *TrackerResponse, err os.Error) {
 	if r.StatusCode >= 400 {
 		data, _ := ioutil.ReadAll(r.Body)
 		reason := "Bad Request " + string(data)
-		log.Stderr(reason)
+		log.Println(reason)
 		err = os.NewError(reason)
 		return
 	}

--- a/taipei/peer.go
+++ b/taipei/peer.go
@@ -151,8 +151,8 @@ func uint32ToBytes(buf []byte, n uint32) {
 }
 
 func writeNBOUint32(conn net.Conn, n uint32) (err os.Error) {
-	var buf [4]byte
-	uint32ToBytes(&buf, n)
+	var buf []byte = make([]byte, 4)
+	uint32ToBytes(buf, n)
 	_, err = conn.Write(buf[0:])
 	return
 }


### PR DESCRIPTION
Hi-

New release changed log package. log.Stderr is no longer supported. Equivalent is log.Println

Two instances of buffer array variables changed to slices. Modified the variable declarations to support this.

Nathan
