### PR TITLE
Dont close the channel more than once.

### DIFF
--- a/taipei/peer.go
+++ b/taipei/peer.go
@@ -3,6 +3,7 @@ package taipei
 import (
 	"io"
 	"net"
+	"sync"
 	"time"
 )
 
@@ -30,14 +31,14 @@ type peerState struct {
 	peer_interested bool // peer is interested in this client
 	peer_requests   map[uint64]bool
 	our_requests    map[uint64]time.Time // What we requested, when we requested it
+	end             sync.Once
 }
 
 func queueingWriter(in, out chan []byte) {
 	queue := make(map[int][]byte)
 	head, tail := 0, 0
-	closed := false
 L:
-	for !closed {
+	for {
 		if head == tail {
 			select {
 			case m, ok := <-in:
@@ -77,13 +78,10 @@ func NewPeerState(conn net.Conn) *peerState {
 }
 
 func (p *peerState) Close() {
-	p.conn.Close()
-	select {
-	case _, ok := <-p.writeChan:
-		if ok {
-			close(p.writeChan)
-		}
-	}
+	p.end.Do(func() {
+		p.conn.Close()
+		close(p.writeChan)
+	})
 }
 
 func (p *peerState) AddRequest(index, begin, length uint32) {


### PR DESCRIPTION
closed() was unsafe so it was removed from the language, so I'm using sync.Once
instead.
