### PR TITLE
Update to go 'tip' (xml package change)

### DIFF
--- a/README
+++ b/README
@@ -41,6 +41,9 @@ Development Roadmap
 
 Build Instructions
   go build
+  
+Usage Instructions
+  ./Taipei-Torrent -torrent mydownload.torrent
 
 BUGS
 - Need to understand why some peers are sending 16K "port" messages.

--- a/taipei/upnp.go
+++ b/taipei/upnp.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type upnpNAT struct {
@@ -36,7 +37,7 @@ func Discover() (nat NAT, err error) {
 	socket := conn.(*net.UDPConn)
 	defer socket.Close()
 
-	err = socket.SetReadTimeout(3 * 1000 * 1000 * 1000)
+	err = socket.SetDeadline(time.Now().Add(3*time.Second))
 	if err != nil {
 		return
 	}
@@ -159,7 +160,7 @@ func getServiceURL(rootURL string) (url string, err error) {
 		return
 	}
 	var root Root
-	err = xml.Unmarshal(r.Body, &root)
+	err = xml.NewDecoder(r.Body).Decode(&root)
 	if err != nil {
 		return
 	}
@@ -264,7 +265,7 @@ func (n *upnpNAT) AddPortMapping(protocol string, externalPort, internalPort int
 	}
 
 	// TODO: check response to see if the port was forwarded
-	// log.Stderr(message, response)
+	// log.Println(message, response)
 	_ = response
 	return
 }
@@ -283,7 +284,7 @@ func (n *upnpNAT) DeletePortMapping(protocol string, externalPort int) (err erro
 	}
 
 	// TODO: check response to see if the port was deleted
-	// log.Stderr(message, response)
+	// log.Println(message, response)
 	_ = response
 	return
 }

--- a/test.bash
+++ b/test.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 # Test the torrent
 
-./taipeitorrent -torrent=testData/a.torrent -fileDir=testData/downloads -port=63881 -useUPnP=true
+./Taipei-Torrent -torrent=testData/a.torrent -fileDir=testData/downloads -port=63881 -useUPnP=true
 # ./taipeitorrent -torrent=testData/a.torrent -fileDir=testData/downloads -port 63881


### PR DESCRIPTION
Also clarifies that the name of the binary changed from "taipeitorrent"
to "Taipei-Torrent", following the new go tool conventions.
