### PR TITLE
Magnet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Usage Instructions
 ------------------
 
     Taipei-Torrent mydownload.torrent
+    Taipei-Torrent --useDHT "magnet:?xt=urn:btih:bbb6db69965af769f664b6636e7914f8735141b3"
 
 or
 

--- a/main.go
+++ b/main.go
@@ -42,6 +42,8 @@ func main() {
 	torrent = args[0]
 
 	log.Println("Starting.")
+	var err error
+
 	ts, err := NewTorrentSession(torrent)
 	if err != nil {
 		log.Println("Could not create torrent session.", err)

--- a/torrent.go
+++ b/torrent.go
@@ -1,20 +1,25 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
+	"crypto/sha1"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"math/rand"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
+	bencode "code.google.com/p/bencode-go"
 	"github.com/nictuku/dht"
 	"github.com/nictuku/nettools"
 )
@@ -37,7 +42,18 @@ const (
 	REQUEST
 	PIECE
 	CANCEL
-	PORT // Not implemented. For DHT support.
+	PORT      // Not implemented. For DHT support.
+	EXTENSION = 20
+)
+
+const (
+	EXTENSION_HANDSHAKE = iota
+)
+
+const (
+	METADATA_REQUEST = iota
+	METADATA_DATA
+	METADATA_REJECT
 )
 
 // Should be overriden by flag. Not thread safe.
@@ -251,15 +267,63 @@ func NewTorrentSession(torrent string) (ts *TorrentSession, err error) {
 		quit:            make(chan bool),
 	}
 
+	if useDHT {
+		// TODO: UPnP UDP port mapping.
+		if t.dht, err = dht.NewDHTNode(listenPort, TARGET_NUM_PEERS, true); err != nil {
+			log.Println("DHT node creation error", err)
+			return
+		}
+		go t.dht.DoDHT()
+	}
+
+	fromMagnet := strings.HasPrefix(torrent, "magnet:")
 	t.m, err = getMetaInfo(torrent)
 	if err != nil {
 		return
 	}
+
+	t.si = &SessionInfo{
+		PeerId:      peerId(),
+		Port:        listenPort,
+		UseDHT:      useDHT,
+		FromMagnet:  fromMagnet,
+		HaveTorrent: false,
+		ME:          &MetaDataExchange{},
+	}
+
+	if !t.si.FromMagnet {
+		t.load()
+	}
+
+	if t.si.UseDHT {
+		log.Println("Waiting 5 seconds for the DHT to fill")
+		time.Sleep(5 * time.Second)
+	}
+
+	return t, err
+}
+
+func (t *TorrentSession) reload(metadata string) {
+	var info InfoDict
+	err := bencode.Unmarshal(bytes.NewReader([]byte(metadata)), &info)
+	if err != nil {
+		log.Println("Error when reloading torrent: ", err)
+		return
+	}
+
+	t.m.Info = info
+	t.load()
+}
+
+func (t *TorrentSession) load() {
+	var err error
+
 	log.Printf("Tracker: %v, Comment: %v, InfoHash: %x, Encoding: %v, Private: %v",
 		t.m.Announce, t.m.Comment, t.m.InfoHash, t.m.Encoding, t.m.Info.Private)
 	if e := t.m.Encoding; e != "" && e != "UTF-8" {
-		return nil, fmt.Errorf("Unknown encoding %s", e)
+		return
 	}
+
 	ext := ".torrent"
 	dir := fileDir
 	if len(t.m.Info.Files) != 0 {
@@ -291,16 +355,8 @@ func NewTorrentSession(torrent string) (ts *TorrentSession, err error) {
 	if !t.pieceSet.IsSet(t.totalPieces - 1) {
 		left = left - t.m.Info.PieceLength + int64(t.lastPieceLength)
 	}
-	t.si = &SessionInfo{PeerId: peerId(), Port: listenPort, Left: left}
-	if useDHT {
-		// TODO: UPnP UDP port mapping.
-		if t.dht, err = dht.NewDHTNode(listenPort, TARGET_NUM_PEERS, true); err != nil {
-			log.Println("DHT node creation error", err)
-			return
-		}
-		go t.dht.DoDHT()
-	}
-	return t, err
+
+	t.si.HaveTorrent = true
 }
 
 func (t *TorrentSession) fetchTrackerInfo(event string) {
@@ -365,9 +421,13 @@ func (t *TorrentSession) AddPeer(conn net.Conn) {
 	ps.address = peer
 	var header [68]byte
 	copy(header[0:], kBitTorrentHeader[0:])
-	if t.m.Info.Private != 1 && useDHT {
+	if t.si.UseDHT {
 		header[27] = header[27] | 0x01
 	}
+	// Support Extension Protocol (BEP-0010)
+	header[25] |= 0x10
+	t.si.OurExtensions = map[int]string{1: "ut_metadata"}
+
 	copy(header[28:48], string2Bytes(t.m.InfoHash))
 	copy(header[48:68], string2Bytes(t.si.PeerId))
 
@@ -375,10 +435,14 @@ func (t *TorrentSession) AddPeer(conn net.Conn) {
 	go ps.peerWriter(t.peerMessageChan, header[0:])
 	go ps.peerReader(t.peerMessageChan)
 	ps.SetChoke(false) // TODO: better choke policy
-	ps.SendBitfield(t.pieceSet)
+	ps.SendExtensions(t.si.Port)
 }
 
 func (t *TorrentSession) ClosePeer(peer *peerState) {
+	if t.si.ME != nil && !t.si.ME.Transferring {
+		t.si.ME.Transferring = false
+	}
+
 	log.Println("Closing peer", peer.address)
 	_ = t.removeRequests(peer)
 	peer.Close()
@@ -421,11 +485,13 @@ func (t *TorrentSession) DoTorrent() (err error) {
 		t.listenForPeerConnections(conChan)
 	}
 
-	if t.m.Info.Private != 1 && useDHT {
+	if t.si.UseDHT {
 		t.dht.PeersRequest(t.m.InfoHash, true)
 	}
 
-	t.fetchTrackerInfo("started")
+	if !trackerLessMode && t.si.HaveTorrent {
+		t.fetchTrackerInfo("started")
+	}
 
 	for {
 		var peersRequestResults chan map[dht.InfoHash][]string
@@ -498,7 +564,12 @@ func (t *TorrentSession) DoTorrent() (err error) {
 				t.ClosePeer(peer)
 			}
 		case conn := <-conChan:
-			t.AddPeer(conn)
+			// Add a new peer only if we are in data transfer mode. If we are
+			// still exchanging metadata, we don't add it (because we're only
+			// getting metadata from 1 peer)
+			if t.si.HaveTorrent || t.si.ME != nil && !t.si.ME.Transferring {
+				t.AddPeer(conn)
+			}
 		case _ = <-rechokeChan:
 			// TODO: recalculate who to choke / unchoke
 			t.heartbeat <- true
@@ -510,7 +581,7 @@ func (t *TorrentSession) DoTorrent() (err error) {
 				"uploaded:", t.si.Uploaded, "ratio", ratio)
 			log.Println("good, total", t.goodPieces, t.totalPieces)
 			if len(t.peers) < TARGET_NUM_PEERS && t.goodPieces < t.totalPieces {
-				if t.m.Info.Private != 1 && useDHT {
+				if t.si.UseDHT {
 					go t.dht.PeersRequest(t.m.InfoHash, true)
 				}
 				if !trackerLessMode {
@@ -745,7 +816,7 @@ func (t *TorrentSession) DoMessage(p *peerState, message []byte) (err error) {
 	}
 	if len(p.id) == 0 {
 		// This is the header message from the peer.
-		if t.m.Info.Private != 1 && useDHT {
+		if t.si.UseDHT {
 			// If 128, then it supports DHT.
 			if int(message[7])&0x01 == 0x01 {
 				// It's OK if we know this node already. The DHT engine will
@@ -759,162 +830,321 @@ func (t *TorrentSession) DoMessage(p *peerState, message []byte) (err error) {
 			return errors.New("this peer doesn't have the right info hash")
 		}
 		p.id = string(message[28:48])
+		if int(message[5])&0x10 == 0x10 {
+			p.SendExtensions(t.si.Port)
+		}
 	} else {
 		if len(message) == 0 { // keep alive
 			return
 		}
-		messageId := message[0]
-		// Message 5 is optional, but must be sent as the first message.
-		if p.have == nil && messageId != 5 {
-			// Fill out the have bitfield
-			p.have = NewBitset(t.totalPieces)
-		}
-		switch id := message[0]; id {
-		case CHOKE:
-			// log.Println("choke", p.address)
-			if len(message) != 1 {
-				return errors.New("Unexpected length")
-			}
-			err = t.doChoke(p)
-		case UNCHOKE:
-			// log.Println("unchoke", p.address)
-			if len(message) != 1 {
-				return errors.New("Unexpected length")
-			}
-			p.peer_choking = false
-			for i := 0; i < MAX_OUR_REQUESTS; i++ {
-				err = t.RequestBlock(p)
-				if err != nil {
-					return
-				}
-			}
-		case INTERESTED:
-			// log.Println("interested", p)
-			if len(message) != 1 {
-				return errors.New("Unexpected length")
-			}
-			p.peer_interested = true
-			// TODO: Consider unchoking
-		case NOT_INTERESTED:
-			// log.Println("not interested", p)
-			if len(message) != 1 {
-				return errors.New("Unexpected length")
-			}
-			p.peer_interested = false
-		case HAVE:
-			if len(message) != 5 {
-				return errors.New("Unexpected length")
-			}
-			n := bytesToUint32(message[1:])
-			if n < uint32(p.have.n) {
-				p.have.Set(int(n))
-				if !p.am_interested && !t.pieceSet.IsSet(int(n)) {
-					p.SetInterested(true)
-				}
-			} else {
-				return errors.New("have index is out of range.")
-			}
-		case BITFIELD:
-			// log.Println("bitfield", p.address)
-			if p.have != nil {
-				return errors.New("Late bitfield operation")
-			}
-			p.have = NewBitsetFromBytes(t.totalPieces, message[1:])
-			if p.have == nil {
-				return errors.New("Invalid bitfield data.")
-			}
-			t.checkInteresting(p)
-		case REQUEST:
-			// log.Println("request", p.address)
-			if len(message) != 13 {
-				return errors.New("Unexpected message length")
-			}
-			index := bytesToUint32(message[1:5])
-			begin := bytesToUint32(message[5:9])
-			length := bytesToUint32(message[9:13])
-			if index >= uint32(p.have.n) {
-				return errors.New("piece out of range.")
-			}
-			if !t.pieceSet.IsSet(int(index)) {
-				return errors.New("we don't have that piece.")
-			}
-			if int64(begin) >= t.m.Info.PieceLength {
-				return errors.New("begin out of range.")
-			}
-			if int64(begin)+int64(length) > t.m.Info.PieceLength {
-				return errors.New("begin + length out of range.")
-			}
-			// TODO: Asynchronous
-			// p.AddRequest(index, begin, length)
-			return t.sendRequest(p, index, begin, length)
-		case PIECE:
-			// piece
-			if len(message) < 9 {
-				return errors.New("unexpected message length")
-			}
-			index := bytesToUint32(message[1:5])
-			begin := bytesToUint32(message[5:9])
-			length := len(message) - 9
-			if index >= uint32(p.have.n) {
-				return errors.New("piece out of range.")
-			}
-			if t.pieceSet.IsSet(int(index)) {
-				// We already have that piece, keep going
-				break
-			}
-			if int64(begin) >= t.m.Info.PieceLength {
-				return errors.New("begin out of range.")
-			}
-			if int64(begin)+int64(length) > t.m.Info.PieceLength {
-				return errors.New("begin + length out of range.")
-			}
-			if length > 128*1024 {
-				return errors.New("Block length too large.")
-			}
-			globalOffset := int64(index)*t.m.Info.PieceLength + int64(begin)
-			_, err = t.fileStore.WriteAt(message[9:], globalOffset)
-			if err != nil {
-				return err
-			}
-			t.RecordBlock(p, index, begin, uint32(length))
-			err = t.RequestBlock(p)
-		case CANCEL:
-			// log.Println("cancel")
-			if len(message) != 13 {
-				return errors.New("Unexpected message length")
-			}
-			index := bytesToUint32(message[1:5])
-			begin := bytesToUint32(message[5:9])
-			length := bytesToUint32(message[9:13])
-			if index >= uint32(p.have.n) {
-				return errors.New("piece out of range.")
-			}
-			if !t.pieceSet.IsSet(int(index)) {
-				return errors.New("we don't have that piece.")
-			}
-			if int64(begin) >= t.m.Info.PieceLength {
-				return errors.New("begin out of range.")
-			}
-			if int64(begin)+int64(length) > t.m.Info.PieceLength {
-				return errors.New("begin + length out of range.")
-			}
-			if length != STANDARD_BLOCK_LENGTH {
-				return errors.New("Unexpected block length.")
-			}
-			p.CancelRequest(index, begin, length)
-		case PORT:
-			// TODO: Implement this message.
-			// We see peers sending us 16K byte messages here, so
-			// it seems that we don't understand what this is.
-			if len(message) != 3 {
-				return fmt.Errorf("Unexpected length for port message: %d", len(message))
-			}
-			go t.dht.AddNode(p.address)
-		default:
-			return errors.New("Uknown message id")
+
+		if t.si.HaveTorrent {
+			err = t.generalMessage(message, p)
+		} else {
+			err = t.extensionMessage(message, p)
 		}
 	}
 	return
+}
+
+func (t *TorrentSession) extensionMessage(message []byte, p *peerState) (err error) {
+	if message[0] == EXTENSION {
+		err := t.DoExtension(message[1:], p)
+		if err != nil {
+			log.Printf("Failed extensions for %s: %s\n", p.address, err)
+		}
+	}
+	return
+}
+
+func (t *TorrentSession) generalMessage(message []byte, p *peerState) (err error) {
+	messageId := message[0]
+
+	switch messageId {
+	case CHOKE:
+		// log.Println("choke", p.address)
+		if len(message) != 1 {
+			return errors.New("Unexpected length")
+		}
+		err = t.doChoke(p)
+	case UNCHOKE:
+		// log.Println("unchoke", p.address)
+		if len(message) != 1 {
+			return errors.New("Unexpected length")
+		}
+		p.peer_choking = false
+		for i := 0; i < MAX_OUR_REQUESTS; i++ {
+			err = t.RequestBlock(p)
+			if err != nil {
+				return
+			}
+		}
+	case INTERESTED:
+		// log.Println("interested", p)
+		if len(message) != 1 {
+			return errors.New("Unexpected length")
+		}
+		p.peer_interested = true
+		// TODO: Consider unchoking
+	case NOT_INTERESTED:
+		// log.Println("not interested", p)
+		if len(message) != 1 {
+			return errors.New("Unexpected length")
+		}
+		p.peer_interested = false
+	case HAVE:
+		if len(message) != 5 {
+			return errors.New("Unexpected length")
+		}
+		n := bytesToUint32(message[1:])
+		if n < uint32(p.have.n) {
+			p.have.Set(int(n))
+			if !p.am_interested && !t.pieceSet.IsSet(int(n)) {
+				p.SetInterested(true)
+			}
+		} else {
+			return errors.New("have index is out of range.")
+		}
+	case BITFIELD:
+		// log.Println("bitfield", p.address)
+		if p.have != nil {
+			return errors.New("Late bitfield operation")
+		}
+		p.have = NewBitsetFromBytes(t.totalPieces, message[1:])
+		if p.have == nil {
+			return errors.New("Invalid bitfield data.")
+		}
+		t.checkInteresting(p)
+	case REQUEST:
+		// log.Println("request", p.address)
+		if len(message) != 13 {
+			return errors.New("Unexpected message length")
+		}
+		index := bytesToUint32(message[1:5])
+		begin := bytesToUint32(message[5:9])
+		length := bytesToUint32(message[9:13])
+		if index >= uint32(p.have.n) {
+			return errors.New("piece out of range.")
+		}
+		if !t.pieceSet.IsSet(int(index)) {
+			return errors.New("we don't have that piece.")
+		}
+		if int64(begin) >= t.m.Info.PieceLength {
+			return errors.New("begin out of range.")
+		}
+		if int64(begin)+int64(length) > t.m.Info.PieceLength {
+			return errors.New("begin + length out of range.")
+		}
+		// TODO: Asynchronous
+		// p.AddRequest(index, begin, length)
+		return t.sendRequest(p, index, begin, length)
+	case PIECE:
+		// piece
+		if len(message) < 9 {
+			return errors.New("unexpected message length")
+		}
+		index := bytesToUint32(message[1:5])
+		begin := bytesToUint32(message[5:9])
+		length := len(message) - 9
+		if index >= uint32(p.have.n) {
+			return errors.New("piece out of range.")
+		}
+		if t.pieceSet.IsSet(int(index)) {
+			// We already have that piece, keep going
+			break
+		}
+		if int64(begin) >= t.m.Info.PieceLength {
+			return errors.New("begin out of range.")
+		}
+		if int64(begin)+int64(length) > t.m.Info.PieceLength {
+			return errors.New("begin + length out of range.")
+		}
+		if length > 128*1024 {
+			return errors.New("Block length too large.")
+		}
+		globalOffset := int64(index)*t.m.Info.PieceLength + int64(begin)
+		_, err = t.fileStore.WriteAt(message[9:], globalOffset)
+		if err != nil {
+			return err
+		}
+		t.RecordBlock(p, index, begin, uint32(length))
+		err = t.RequestBlock(p)
+	case CANCEL:
+		// log.Println("cancel")
+		if len(message) != 13 {
+			return errors.New("Unexpected message length")
+		}
+		index := bytesToUint32(message[1:5])
+		begin := bytesToUint32(message[5:9])
+		length := bytesToUint32(message[9:13])
+		if index >= uint32(p.have.n) {
+			return errors.New("piece out of range.")
+		}
+		if !t.pieceSet.IsSet(int(index)) {
+			return errors.New("we don't have that piece.")
+		}
+		if int64(begin) >= t.m.Info.PieceLength {
+			return errors.New("begin out of range.")
+		}
+		if int64(begin)+int64(length) > t.m.Info.PieceLength {
+			return errors.New("begin + length out of range.")
+		}
+		if length != STANDARD_BLOCK_LENGTH {
+			return errors.New("Unexpected block length.")
+		}
+		p.CancelRequest(index, begin, length)
+	case PORT:
+		// TODO: Implement this message.
+		// We see peers sending us 16K byte messages here, so
+		// it seems that we don't understand what this is.
+		if len(message) != 3 {
+			return fmt.Errorf("Unexpected length for port message: %d", len(message))
+		}
+		go t.dht.AddNode(p.address)
+	case EXTENSION:
+		err := t.DoExtension(message[1:], p)
+		if err != nil {
+			log.Printf("Failed extensions for %s: %s\n", p.address, err)
+		}
+
+		if t.si.HaveTorrent {
+			p.SendBitfield(t.pieceSet)
+		}
+	default:
+		return errors.New(fmt.Sprintf("Uknown message id: %d\n", messageId))
+	}
+
+	return
+}
+
+type ExtensionHandshake struct {
+	M      map[string]int "m"
+	P      uint16         "p"
+	V      string         "v"
+	Yourip string         "yourip"
+	Ipv6   string         "ipv6"
+	Ipv4   string         "ipv4"
+	Reqq   uint16         "reqq"
+
+	MetadataSize uint "metadata_size"
+}
+
+func (t *TorrentSession) DoExtension(msg []byte, p *peerState) (err error) {
+
+	var h ExtensionHandshake
+	if msg[0] == EXTENSION_HANDSHAKE {
+		err = bencode.Unmarshal(bytes.NewReader(msg[1:]), &h)
+		if err != nil {
+			log.Println("Error when unmarshaling extension handshake")
+			return err
+		}
+
+		p.theirExtensions = make(map[string]int)
+		for name, code := range h.M {
+			p.theirExtensions[name] = code
+		}
+
+		if t.si.HaveTorrent || t.si.ME != nil && t.si.ME.Transferring {
+			return
+		}
+
+		// Fill metadata info
+		if h.MetadataSize != uint(0) {
+			nPieces := uint(math.Ceil(float64(h.MetadataSize) / float64(16*1024)))
+			t.si.ME.Pieces = make([][]byte, nPieces)
+		}
+
+		if _, ok := p.theirExtensions["ut_metadata"]; ok {
+			t.si.ME.Transferring = true
+			p.sendMetadataRequest(0)
+		}
+
+	} else if ext, ok := t.si.OurExtensions[int(msg[0])]; ok {
+		switch ext {
+		case "ut_metadata":
+			t.DoMetadata(msg[1:], p)
+		default:
+			log.Println("Unknown extension: ", ext)
+		}
+	} else {
+		log.Println("Unknown extension: ", int(msg[0]))
+	}
+
+	return nil
+}
+
+type MetadataMessage struct {
+	MsgType   uint8 "msg_type"
+	Piece     uint  "piece"
+	TotalSize uint  "total_size"
+}
+
+func (t *TorrentSession) DoMetadata(msg []byte, p *peerState) {
+	// We need a buffered reader because the raw data is put directly
+	// after the bencoded data, and a simple reader will get all its bytes
+	// eaten. A buffered reader will keep a reference to where the
+	// bdecoding ended.
+	br := bufio.NewReader(bytes.NewReader(msg))
+	var message MetadataMessage
+	err := bencode.Unmarshal(br, &message)
+	if err != nil {
+		log.Println("Error when parsing metadata: ", err)
+		return
+	}
+
+	mt := message.MsgType
+	switch mt {
+	case METADATA_REQUEST:
+		//TODO: Answer to metadata request
+	case METADATA_DATA:
+
+		var piece bytes.Buffer
+		_, err := io.Copy(&piece, br)
+		if err != nil {
+			log.Println("Error when getting metadata piece: ", err)
+			return
+		}
+		t.si.ME.Pieces[message.Piece] = piece.Bytes()
+
+		finished := true
+		for idx, data := range t.si.ME.Pieces {
+			if len(data) == 0 {
+				p.sendMetadataRequest(idx)
+				finished = false
+			}
+		}
+
+		if !finished {
+			break
+		}
+
+		log.Println("Finished downloading metadata!")
+		var full bytes.Buffer
+		for _, piece := range t.si.ME.Pieces {
+			full.Write(piece)
+		}
+		b := full.Bytes()
+
+		// Verify sha
+		sha := sha1.New()
+		sha.Write(b)
+		actual := string(sha.Sum(nil))
+		if actual != t.m.InfoHash {
+			log.Println("Invalid metadata")
+			log.Printf("Expected %s, got %s\n", t.m.InfoHash, actual)
+		}
+
+		metadata := string(b)
+		err = saveMetaInfo(metadata)
+		if err != nil {
+			return
+		}
+		t.reload(metadata)
+	case METADATA_REJECT:
+		log.Printf("%d didn't want to send piece %d\n", p.address, message.Piece)
+	default:
+		log.Println("Didn't understand metadata extension type: ", mt)
+	}
 }
 
 func (t *TorrentSession) sendRequest(peer *peerState, index, begin, length uint32) (err error) {

--- a/uri.go
+++ b/uri.go
@@ -3,13 +3,16 @@ package main
 import (
 	"crypto/sha1"
 	"fmt"
-	"io"
+	_ "io"
 	"net/url"
 	"strings"
+
+	_ "github.com/nictuku/dht"
 )
 
 type Magnet struct {
 	InfoHashes []string
+	Names      []string
 }
 
 func parseMagnet(s string) (Magnet, error) {
@@ -23,7 +26,7 @@ func parseMagnet(s string) (Magnet, error) {
 	//
 	// xt: exact topic.
 	//   ~ urn: uniform resource name.
-	//   ~ btih: bittorrent infohash. 
+	//   ~ btih: bittorrent infohash.
 	// dn: display name (optional).
 	// tr: address tracker (optional).
 	u, err := url.Parse(s)
@@ -47,25 +50,12 @@ func parseMagnet(s string) (Magnet, error) {
 		}
 		infoHashes = append(infoHashes, s[1])
 	}
-	return Magnet{infoHashes}, nil
-}
 
-// torrentFromMagnet fetches the content of a torrent meta file from the magnet
-// uri. It only uses the first infohash found in the URI.
-func torrentFromMagnet(uri string) (torrentBody io.ReadCloser, err error) {
-	m, err := parseMagnet(uri)
-	if err != nil {
-		return nil, err
+	var names []string
+	n, ok := u.Query()["dn"]
+	if ok {
+		names = n
 	}
-	if len(m.InfoHashes) == 0 {
-		return nil, fmt.Errorf("No bittorrent infohashes found in the magnet link %v.", uri)
-	}
-	ih := m.InfoHashes[0]
-	return nil, fmt.Errorf("Not supported. Would have downloaded torrent file with hash %v", ih)
 
-	// Start a torrent session to download the magnet file.
-	//
-	// References:
-	// - http://bittorrent.org/beps/bep_0009.html
-	// TODO: Refactor the torrent code to support multiple sessions per client.
+	return Magnet{InfoHashes: infoHashes, Names: names}, nil
 }


### PR DESCRIPTION
A pretty big change, that depends on #22.

Here, instead of starting exchanging the data directly (because we don't know about it), we set a few shortcuts to handle communication through the DoMetadata method. Once metadata has completely arrived, we disable the shortcuts to treat communication as usual.

This metadata handling happens mainly in `torrent.go`, which starts to be pretty big.. I believe it's time to spread the logic, in the direction of multi torrents
