### PR TITLE
Add default bitfield for new peerstates

### DIFF
--- a/torrent.go
+++ b/torrent.go
@@ -350,6 +350,10 @@ func (t *TorrentSession) AddPeer(btconn *btConn) {
 		}
 	}
 
+	// By default, a peer has no pieces. If it has pieces, it should send
+	// a BITFIELD message as a first message
+	ps.have = NewBitset(t.totalPieces)
+
 	t.peers[peer] = ps
 	go ps.peerWriter(t.peerMessageChan)
 	go ps.peerReader(t.peerMessageChan)


### PR DESCRIPTION
By default, a new peer has no pieces, so it doesn't send a BITFIELD. Only when it has some (or all) pieces does it send a BITFIELD. In the current implementation we only build peerstates' have when receiving BITFIELD. This fix makes sure there is always a have by default.
