### PR TITLE
Use the new DHT API

### DIFF
--- a/torrent.go
+++ b/torrent.go
@@ -447,6 +447,9 @@ func (t *TorrentSession) Quit() (err error) {
 	for _, peer := range t.peers {
 		t.ClosePeer(peer)
 	}
+	if t.dht != nil {
+		t.dht.Stop()
+	}
 	return nil
 }
 


### PR DESCRIPTION
NewDHTNode and DoDHT have been deprecated in favor of better named and more flexible methods.

This change should be a no-op.
