### PR TITLE
Implement lpd

### DIFF
--- a/lpd.go
+++ b/lpd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"flag"
 	"fmt"
 	"log"
 	"net"
@@ -10,6 +11,7 @@ import (
 	"time"
 )
 
+var useLPD = flag.Bool("useLPD", false, "Use Local Peer Discovery")
 var (
 	request_template = "BT-SEARCH * HTTP/1.1\r\n" +
 		"Host: 239.192.152.143:6771\r\n" +
@@ -106,7 +108,7 @@ func (lpd *Announcer) Announce(ih string) {
 			log.Println(err)
 		}
 
-		ticker := time.NewTicker(5 * time.Second)
+		ticker := time.NewTicker(5 * time.Minute)
 		lpd.activeAnnounces[ih] = ticker
 
 		for _ = range ticker.C {
@@ -121,5 +123,6 @@ func (lpd *Announcer) Announce(ih string) {
 func (lpd *Announcer) StopAnnouncing(ih string) {
 	if ticker, ok := lpd.activeAnnounces[ih]; ok {
 		ticker.Stop()
+		delete(lpd.activeAnnounces, ih)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 var (
 	cpuprofile = flag.String("cpuprofile", "", "If not empty, collects CPU profile samples and writes the profile to the given file before the program exits")
 	memprofile = flag.String("memprofile", "", "If not empty, writes memory heap allocations to the given file before the program exits")
-	useLPD     = flag.Bool("useLPD", true, "Use Local Peer Discovery")
 )
 
 var torrent string
@@ -74,7 +73,7 @@ func main() {
 		go ts.DoTorrent()
 	}
 
-	var lpd *Announcer
+	lpd := &Announcer{}
 	if *useLPD {
 		lpd = startLPD(torrentSessions, listenPort)
 	}


### PR DESCRIPTION
As should be defined in BEP-0014 (still TBD)

Basically, for each torrent we are in, a HTTP-like message is sent to
239.192.152.143:6771. This message is an announcement that we are in
the swarm.

When a Taipei-Torrent peer receives such a message, it will
automatically connect unless it's already connected.

Tested successfully with aria2c and transmission.
