### PR TITLE
Add tags to XML-related structs

### DIFF
--- a/upnp.go
+++ b/upnp.go
@@ -94,22 +94,23 @@ func Discover() (nat NAT, err error) {
 }
 
 type Service struct {
-	ServiceType string
-	ControlURL  string
+	ServiceType string `xml:"serviceType"`
+	ControlURL  string `xml:"controlURL"`
 }
 
 type DeviceList struct {
-	Device []Device
+	Device []Device `xml:"device"`
 }
 
 type ServiceList struct {
-	Service []Service
+	Service []Service `xml:"service"`
 }
 
 type Device struct {
-	DeviceType  string
-	DeviceList  DeviceList
-	ServiceList ServiceList
+	XMLName xml.Name `xml:"device"`
+	DeviceType  string `xml:"deviceType"`
+	DeviceList  DeviceList `xml:"deviceList"`
+	ServiceList ServiceList `xml:"serviceList"`
 }
 
 type Root struct {


### PR DESCRIPTION
By default, the `xml` package matches the names of the fields in a struct to XML element names. However, it's necessary to start all struct fields with capital letters so they are exported. Since the data returned by a UPnP device doesn't start with a capital letter, it won't match. This causes the XML-related structs not to be filled in, because the element names don't match any XML elements.

For example, take the `Device` struct. The `xml` package looks for an XML element with the name `Device`. However, the actual element is called `device`, so it doesn't find a match. I've added tags to all of the struct fields, which the `xml` package will use instead.
