### PR TITLE
Separate code into package 'taipei'

### DIFF
--- a/torrent/bitset.go
+++ b/torrent/bitset.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 // As defined by the bittorrent protocol, this bitset is big-endian, such that
 // the high bit of the first byte is block 0

--- a/torrent/files.go
+++ b/torrent/files.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 import (
 	"errors"

--- a/torrent/files_test.go
+++ b/torrent/files_test.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 import (
 	"crypto/sha1"

--- a/torrent/listen.go
+++ b/torrent/listen.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 import (
 	"flag"
@@ -21,15 +21,15 @@ var (
 type btConn struct {
 	conn     net.Conn
 	header   []byte
-	infohash string
+	Infohash string
 	id       string
 }
 
 // listenForPeerConnections listens on a TCP port for incoming connections and
 // demuxes them to the appropriate active torrentSession based on the InfoHash
 // in the header.
-func listenForPeerConnections() (conChan chan *btConn, listenPort int, err error) {
-	listener, err := createListener()
+func ListenForPeerConnections() (conChan chan *btConn, listenPort int, err error) {
+	listener, err := CreateListener()
 	if err != nil {
 		return
 	}
@@ -61,7 +61,7 @@ func listenForPeerConnections() (conChan chan *btConn, listenPort int, err error
 			id := string(header[28:48])
 			conChan <- &btConn{
 				header:   header,
-				infohash: peersInfoHash,
+				Infohash: peersInfoHash,
 				id:       id,
 				conn:     conn,
 			}
@@ -70,8 +70,8 @@ func listenForPeerConnections() (conChan chan *btConn, listenPort int, err error
 	return
 }
 
-func createListener() (listener net.Listener, err error) {
-	nat, err := createPortMapping()
+func CreateListener() (listener net.Listener, err error) {
+	nat, err := CreatePortMapping()
 	if err != nil {
 		err = fmt.Errorf("Unable to create NAT: %v", err)
 		return
@@ -98,7 +98,7 @@ func createListener() (listener net.Listener, err error) {
 }
 
 // createPortMapping creates a NAT port mapping, or nil if none requested or found.
-func createPortMapping() (nat NAT, err error) {
+func CreatePortMapping() (nat NAT, err error) {
 	if *useUPnP && *useNATPMP {
 		err = fmt.Errorf("Cannot specify both -useUPnP and -useNATPMP")
 		return

--- a/torrent/lpd.go
+++ b/torrent/lpd.go
@@ -1,9 +1,8 @@
-package main
+package torrent
 
 import (
 	"bufio"
 	"bytes"
-	"flag"
 	"fmt"
 	"log"
 	"net"
@@ -11,7 +10,6 @@ import (
 	"time"
 )
 
-var useLPD = flag.Bool("useLPD", false, "Use Local Peer Discovery")
 var (
 	request_template = "BT-SEARCH * HTTP/1.1\r\n" +
 		"Host: 239.192.152.143:6771\r\n" +
@@ -20,8 +18,8 @@ var (
 )
 
 type Announce struct {
-	peer     string
-	infohash string
+	Peer     string
+	Infohash string
 }
 
 type Announcer struct {
@@ -29,7 +27,7 @@ type Announcer struct {
 	addr   *net.UDPAddr
 	conn   *net.UDPConn
 
-	announces       chan *Announce
+	Announces       chan *Announce
 	activeAnnounces map[string]*time.Ticker
 }
 
@@ -49,7 +47,7 @@ func NewAnnouncer(listenPort int) (lpd *Announcer, err error) {
 		btPort:          listenPort,
 		addr:            addr,
 		conn:            conn,
-		announces:       make(chan *Announce),
+		Announces:       make(chan *Announce),
 		activeAnnounces: activeAnnounces,
 	}
 
@@ -93,7 +91,7 @@ func (lpd *Announcer) run() {
 			log.Println(err)
 			continue
 		}
-		lpd.announces <- &Announce{addr.String(), ih}
+		lpd.Announces <- &Announce{addr.String(), ih}
 	}
 }
 

--- a/torrent/metainfo.go
+++ b/torrent/metainfo.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 import (
 	"bytes"

--- a/torrent/nat.go
+++ b/torrent/nat.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 import (
 	"net"

--- a/torrent/natpmp.go
+++ b/torrent/natpmp.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 import (
 	natpmp "code.google.com/p/go-nat-pmp"

--- a/torrent/peer.go
+++ b/torrent/peer.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 import (
 	"bytes"

--- a/torrent/pieces.go
+++ b/torrent/pieces.go
@@ -1,5 +1,5 @@
 // Compute missing pieces for a torrent.
-package main
+package torrent
 
 import (
 	"crypto/sha1"

--- a/torrent/pieces_test.go
+++ b/torrent/pieces_test.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 import (
 	"crypto/sha1"

--- a/torrent/proxy.go
+++ b/torrent/proxy.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 import (
 	"flag"

--- a/torrent/trackerClient.go
+++ b/torrent/trackerClient.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 import (
 	"fmt"

--- a/torrent/upnp.go
+++ b/torrent/upnp.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 // Just enough UPnP to be able to forward ports
 //

--- a/torrent/uri.go
+++ b/torrent/uri.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 import (
 	"crypto/sha1"

--- a/torrent/uri_test.go
+++ b/torrent/uri_test.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 import (
 	"reflect"


### PR DESCRIPTION
This is the first step towards making Taipei-Torrent available as a library. I've moved all of the files (besides `main.go`) into the `taipei` subdirectory, and changedthem to use the `taipei` package.

There are a lot of changes in the PR, because it's necessary to capitalize the names of all fields used in `main.go`, since none of them were exported. Later, we can decide what fields really should be exported.
