### PR TITLE
Don't use DHT if the torrent is marked private

### DIFF
--- a/torrent/torrent.go
+++ b/torrent/torrent.go
@@ -164,8 +164,8 @@ func NewTorrentSession(torrent string, listenPort uint16) (ts *TorrentSession, e
 		quit:            make(chan bool),
 		torrentFile:     torrent,
 	}
-
-	if useDHT {
+	dhtAllowed := useDHT && t.M.Info.Private == 0
+	if dhtAllowed {
 		// TODO: UPnP UDP port mapping.
 		cfg := dht.NewConfig()
 		cfg.Port = int(listenPort)
@@ -186,7 +186,7 @@ func NewTorrentSession(torrent string, listenPort uint16) (ts *TorrentSession, e
 	t.si = &SessionInfo{
 		PeerId:        peerId(),
 		Port:          listenPort,
-		UseDHT:        useDHT,
+		UseDHT:        dhtAllowed,
 		FromMagnet:    fromMagnet,
 		HaveTorrent:   false,
 		ME:            &MetaDataExchange{},


### PR DESCRIPTION
The BEP is 27. http://bittorrent.org/beps/bep_0027.html

This feels like a very brittle feature to me. It's very easy for clients to leak private information out, if they so wish to. But I see no reason _not_ to implement it..
