### PR TITLE
Fix crash when using DHT.

### DIFF
--- a/torrent/torrent.go
+++ b/torrent/torrent.go
@@ -166,6 +166,11 @@ func NewTorrentSession(torrent string, listenPort uint16) (ts *TorrentSession, e
 		quit:            make(chan bool),
 		torrentFile:     torrent,
 	}
+	fromMagnet := strings.HasPrefix(torrent, "magnet:")
+	t.M, err = getMetaInfo(torrent)
+	if err != nil {
+		return
+	}
 	dhtAllowed := useDHT && t.M.Info.Private == 0
 	if dhtAllowed {
 		// TODO: UPnP UDP port mapping.
@@ -179,11 +184,6 @@ func NewTorrentSession(torrent string, listenPort uint16) (ts *TorrentSession, e
 		go t.dht.Run()
 	}
 
-	fromMagnet := strings.HasPrefix(torrent, "magnet:")
-	t.M, err = getMetaInfo(torrent)
-	if err != nil {
-		return
-	}
 
 	t.si = &SessionInfo{
 		PeerId:        peerId(),


### PR DESCRIPTION
t.M needs to be populated before we can refer to it.

2014/05/04 21:20:03 Starting.
2014/05/04 21:20:03 Listening for peers on port: 7777
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x18 pc=0x3fa6f]

goroutine 16 [running]:
runtime.panic(0x335860, 0x551524)
    /usr/local/go/src/pkg/runtime/panic.c:279 +0xf5
github.com/jackpal/Taipei-Torrent/torrent.NewTorrentSession(0x7fff5fbffb5f, 0x14f, 0x1e61, 0x0, 0x0, 0x0)
    /Users/yves/go/src/github.com/jackpal/Taipei-Torrent/torrent/torrent.go:169 +0x14f
main.main()
    /Users/yves/go/src/github.com/jackpal/Taipei-Torrent/main.go:62 +0x523
