### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+go:
+  - 1.2
+  - 1.3
+  - tip
+
+allowed_failures:
+  - go: tip
+
+install:
+  - go get -d -v ./... && go build -race -v ./...
+
+script: go test -race -v ./...


### PR DESCRIPTION
This allows Taipei-Torrent to be tested on Travis CI.

You'll need to follow [this guide](http://docs.travis-ci.com/user/getting-started/#Step-one%3A-Sign-in) to set up Taipei-Torrent on Travis CI.
