### PR TITLE
Use strconv.Atoi to parse numWant in tracker implementation

### DIFF
--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -130,7 +130,7 @@ func (a *announceParams) parse(u *url.URL) (err error) {
 	}
 	a.event = q.Get("event")
 	if numWant := q.Get("numwant"); numWant != "" {
-		a.numWant, err = getInt(q, numWant)
+		a.numWant, err = strconv.Atoi(numWant)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
I think this is what the code is supposed to do. However, the current implementation will try to get `numWant` as a query parameter, instead of parsing it from the URL.

As an example, if the URL has `numWant=100` in it, line 133 will cause the code to look for a query parameter called `100`, instead of converting `100` to an int.
