### PR TITLE
Checking fs.Stat error

### DIFF
--- a/torrent/metainfo.go
+++ b/torrent/metainfo.go
@@ -240,6 +240,9 @@ func CreateMetaInfoFromFileSystem(fs MetaInfoFileSystem, root string, pieceLengt
 	var m *MetaInfo = &MetaInfo{}
 	var fileInfo os.FileInfo
 	fileInfo, err = fs.Stat(root)
+	if err != nil {
+		return
+	}
 	var totalLength int64
 	if fileInfo.IsDir() {
 		err = m.addFiles(fs, root)


### PR DESCRIPTION
One cannot simply leave error unckecked:

```
panic: runtime error: invalid memory address or nil pointer dereference
```
