### PR TITLE
Toy WebGui.

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,26 +108,16 @@ func main() {
 		}(*memprofile)
 	}
 
-	//Since it's possible someone might want more than one manager at a time, store them in an array.
+	//Since it's possible someone might want more than one manager at a time
+	//e.g. a local gui and a remote gui, store them in an array.
 	managers := make([]torrent.TorrentManager, 0)
-	torrentSessions := torrent.GetSessions(torrentFlags, args)
-	torrentControl := torrent.TorrentControl{torrentSessions}
 
 	if *createWebGui != 0 {
-		managers = append(managers, webgui.WebGui{torrentControl, *createWebGui})
-	}
-
-	log.Println("Starting Managers.")
-	for _, tm := range managers {
-		err := tm.Start()
-		if err != nil {
-			log.Println("Error loading manager:", tm)
-			log.Println("Error:", err)
-		}
+		managers = append(managers, webgui.WebGui{WebPort: *createWebGui})
 	}
 
 	log.Println("Starting Torrents.")
-	err := torrent.RunTorrents(torrentFlags, torrentSessions)
+	err := torrent.RunTorrents(torrentFlags, args, managers)
 	if err != nil {
 		log.Fatal("Could not run torrents", args, err)
 	}

--- a/main.go
+++ b/main.go
@@ -79,10 +79,18 @@ func main() {
 		return
 	}
 
+	//Since it's possible someone might want more than one manager at a time
+	//e.g. a local gui and a remote gui, store them in an array.
+	managers := make([]torrent.TorrentManager, 0)
+
+	if *createWebGui != 0 {
+		managers = append(managers, webgui.NewWebGui(*createWebGui))
+	}
+
 	args := flag.Args()
 	narg := flag.NArg()
 
-	if narg < 1 {
+	if narg < 1 && len(managers) == 0 { //If there's a manager, we'll make an exception since the user can add torrents with it later.
 		log.Println("Too few arguments. Torrent file or torrent URL required.")
 		usage()
 	}
@@ -106,14 +114,6 @@ func main() {
 			}
 			pprof.WriteHeapProfile(memf)
 		}(*memprofile)
-	}
-
-	//Since it's possible someone might want more than one manager at a time
-	//e.g. a local gui and a remote gui, store them in an array.
-	managers := make([]torrent.TorrentManager, 0)
-
-	if *createWebGui != 0 {
-		managers = append(managers, webgui.NewWebGui(*createWebGui))
 	}
 
 	log.Println("Starting Torrents.")

--- a/main.go
+++ b/main.go
@@ -113,7 +113,7 @@ func main() {
 	managers := make([]torrent.TorrentManager, 0)
 
 	if *createWebGui != 0 {
-		managers = append(managers, webgui.WebGui{WebPort: *createWebGui})
+		managers = append(managers, webgui.NewWebGui(*createWebGui))
 	}
 
 	log.Println("Starting Torrents.")

--- a/managers/webgui/webgui.go
+++ b/managers/webgui/webgui.go
@@ -11,9 +11,15 @@ import (
 
 type WebGui struct {
 	//Why double-pointer? Because methods defined by an interface have to act on values
-	//This makes self-modification difficult
+	//This makes self-modification difficult. The "solutions" I've found
+	//are a) using a []TorrentControl or b) this double-pointer stuff
 	torrentCtrl **torrent.TorrentControl
 	WebPort     int
+}
+
+func NewWebGui(port int) WebGui {
+	ref := &torrent.TorrentControl{}
+	return WebGui{&ref, port}
 }
 
 func (wg WebGui) Start(tc *torrent.TorrentControl) error {

--- a/managers/webgui/webgui.go
+++ b/managers/webgui/webgui.go
@@ -1,0 +1,75 @@
+package webgui
+
+import (
+	"code.google.com/p/gowut/gwu"
+	"errors"
+	"fmt"
+	"github.com/jackpal/Taipei-Torrent/torrent"
+	"strconv"
+	"time"
+)
+
+type WebGui struct {
+	TorrentCtrl torrent.TorrentControl
+	WebPort     int
+}
+
+func (wg WebGui) Start() error {
+	if wg.TorrentCtrl.TorrentSessions != nil {
+		go wg.start(wg.WebPort)
+		return nil
+	} else {
+		return errors.New("Didn't get a TorrentControl before starting.")
+	}
+}
+
+func (wg *WebGui) start(port int) {
+	// Create and build a window
+	win := gwu.NewWindow("main", "Status Info")
+	win.Style().SetFullWidth()
+	win.SetHAlign(gwu.HA_CENTER)
+	win.SetCellPadding(2)
+
+	//UpdateTime label
+	updateTime := gwu.NewLabel("")
+	win.Add(updateTime)
+
+	//Panel for torrent labels
+	torrPanel := gwu.NewVerticalPanel()
+	win.Add(torrPanel)
+
+	//torrent label holder
+	torrentLabels := make([]gwu.Label, 0, 16)
+
+	//Timer set for every second
+	t2 := gwu.NewTimer(time.Second)
+	t2.SetRepeat(true)
+	t2.AddEHandlerFunc(func(e gwu.Event) {
+		updateTime.SetText(fmt.Sprintln(time.Now().Format("2006-01-02 15:04:05")))
+		e.MarkDirty(updateTime)
+
+		torrlist := wg.TorrentCtrl.GetTorrentList()
+		for i := len(torrentLabels); i < len(torrlist); i++ {
+			newLabel := gwu.NewLabel("pants")
+			torrentLabels = append(torrentLabels, newLabel)
+			torrPanel.Insert(newLabel, 0)
+			e.MarkDirty(torrPanel)
+		}
+
+		for i, labl := range torrentLabels {
+			if i < len(torrlist) {
+				mpa, _ := wg.TorrentCtrl.GetStatus(torrlist[i])
+				labl.SetText(mpa["Name"] + "  At  " + mpa["Percent"] + "%")
+			} else {
+				labl.SetText("")
+			}
+			e.MarkDirty(labl)
+		}
+	}, gwu.ETYPE_STATE_CHANGE)
+	win.Add(t2)
+
+	server := gwu.NewServer("TaipeiTorrent", "localhost:"+strconv.Itoa(port))
+	server.SetText("TaipeiTorrent WebGui")
+	server.AddWin(win)
+	server.Start("main")
+}

--- a/torrent/listen.go
+++ b/torrent/listen.go
@@ -20,8 +20,9 @@ type BtConn struct {
 // listenForPeerConnections listens on a TCP port for incoming connections and
 // demuxes them to the appropriate active torrentSession based on the InfoHash
 // in the header.
-func ListenForPeerConnections(flags *TorrentFlags) (conChan chan *BtConn, listenPort int, err error) {
-	listener, listenPort, err := CreateListener(flags)
+func ListenForPeerConnections(flags *TorrentFlags) (conChan chan *BtConn, listenPort int, nat NAT, err error) {
+	var listener net.Listener
+	listener, listenPort, nat, err = CreateListener(flags)
 	if err != nil {
 		return
 	}
@@ -58,8 +59,8 @@ func ListenForPeerConnections(flags *TorrentFlags) (conChan chan *BtConn, listen
 	return
 }
 
-func CreateListener(flags *TorrentFlags) (listener net.Listener, externalPort int, err error) {
-	nat, err := CreatePortMapping(flags)
+func CreateListener(flags *TorrentFlags) (listener net.Listener, externalPort int, nat NAT, err error) {
+	nat, err = CreatePortMapping(flags)
 	if err != nil {
 		err = fmt.Errorf("Unable to create NAT: %v", err)
 		return

--- a/torrent/torrent.go
+++ b/torrent/torrent.go
@@ -806,47 +806,54 @@ func (t *TorrentSession) RecordBlock(p *peerState, piece, begin, length uint32) 
 		}
 		t.si.Downloaded += uint64(length)
 		if v.isComplete() {
-			delete(t.activePieces, int(piece))
-			ok, err = checkPiece(t.fileStore, t.totalSize, t.M, int(piece))
-			if !ok || err != nil {
+			if !t.RecordPiece(piece, v.pieceLength) {
 				log.Println("Closing peer that sent a bad piece", piece, p.id, err)
 				p.Close()
 				return
-			}
-			t.si.Left -= uint64(v.pieceLength)
-			t.pieceSet.Set(int(piece))
-			t.goodPieces++
-			var percentComplete float32 = 0
-			if t.totalPieces > 0 {
-				percentComplete = float32(t.goodPieces*100) / float32(t.totalPieces)
-			}
-			log.Println("Have", t.goodPieces, "of", t.totalPieces,
-				"pieces", percentComplete, "% complete.")
-			if t.goodPieces == t.totalPieces {
-				if !t.trackerLessMode {
-					t.fetchTrackerInfo("completed")
-				}
-				// TODO: Drop connections to all seeders.
-			}
-			for _, p := range t.peers {
-				if p.have != nil {
-					if int(piece) < p.have.n && p.have.IsSet(int(piece)) {
-						// We don't do anything special. We rely on the caller
-						// to decide if this peer is still interesting.
-					} else {
-						// log.Println("...telling ", p)
-						haveMsg := make([]byte, 5)
-						haveMsg[0] = HAVE
-						uint32ToBytes(haveMsg[1:5], piece)
-						p.sendMessage(haveMsg)
-					}
-				}
 			}
 		}
 	} else {
 		log.Println("Received a block we already have.", piece, block, p.address)
 	}
 	return
+}
+
+func (t *TorrentSession) RecordPiece(piece uint32, pieceLength int) bool {
+	delete(t.activePieces, int(piece))
+	ok, err := checkPiece(t.fileStore, t.totalSize, t.M, int(piece))
+	if !ok || err != nil {
+		return false
+	}
+	t.si.Left -= uint64(pieceLength)
+	t.pieceSet.Set(int(piece))
+	t.goodPieces++
+	var percentComplete float32 = 0
+	if t.totalPieces > 0 {
+		percentComplete = float32(t.goodPieces*100) / float32(t.totalPieces)
+	}
+	log.Println("Have", t.goodPieces, "of", t.totalPieces,
+		"pieces", percentComplete, "% complete.")
+	if t.goodPieces == t.totalPieces {
+		if !t.trackerLessMode {
+			t.fetchTrackerInfo("completed")
+		}
+		// TODO: Drop connections to all seeders.
+	}
+	for _, p := range t.peers {
+		if p.have != nil {
+			if int(piece) < p.have.n && p.have.IsSet(int(piece)) {
+				// We don't do anything special. We rely on the caller
+				// to decide if this peer is still interesting.
+			} else {
+				// log.Println("...telling ", p)
+				haveMsg := make([]byte, 5)
+				haveMsg[0] = HAVE
+				uint32ToBytes(haveMsg[1:5], piece)
+				p.sendMessage(haveMsg)
+			}
+		}
+	}
+	return true
 }
 
 func (t *TorrentSession) doChoke(p *peerState) (err error) {

--- a/torrent/torrentControl.go
+++ b/torrent/torrentControl.go
@@ -1,0 +1,96 @@
+// torrentControl.go
+package torrent
+
+import (
+	"errors"
+	"strconv"
+)
+
+type TorrentManager interface {
+	Start() error
+}
+
+type TorrentControl struct {
+	TorrentSessions map[string]*TorrentSession
+}
+
+//Add a torrent, by magnet uri, http link, or filepath.
+//'start' determines if torrent contents start downloading immediately.
+//Note: regardless of start bool, magnet uris and http links
+//are fetched immediately for their tasty tasty metadata.
+//Returns the resulting infohash if successful; "" and an error if not
+func (tc *TorrentControl) AddTorrent(torr string, start bool) (string, error) {
+	return "", nil
+}
+
+//Returns a copy of the metadata for a particular torrent if successful;
+//an zero-struct and error if not
+func (tc *TorrentControl) GetMetaData(infohash string) (MetaInfo, error) {
+	return MetaInfo{}, nil
+}
+
+//Returns the status of a particular torrent if successful;
+//nil and an error if not.
+//Also, if infohash == "", should return status info for Taipei-Torrent itself
+func (tc *TorrentControl) GetStatus(infohash string) (map[string]string, error) {
+	ts, ok := tc.TorrentSessions[infohash]
+	if !ok {
+		return nil, errors.New("Infohash not found.")
+	}
+	var percentComplete float64 = 0
+	if ts.totalPieces > 0 {
+		percentComplete = float64(ts.goodPieces*100) / float64(ts.totalPieces)
+	}
+	status := make(map[string]string)
+	status["Percent"] = strconv.FormatFloat(percentComplete, 'f', 1, 64)
+	status["Name"] = ts.torrentFile
+	return status, nil
+}
+
+//Returns an array of infostrings for all the torrents
+func (tc *TorrentControl) GetTorrentList() []string {
+	infoH := make([]string, 0, len(tc.TorrentSessions))
+
+	for key := range tc.TorrentSessions {
+		infoH = append(infoH, key)
+	}
+
+	return infoH
+}
+
+//Sets the pieces wanted for a particular torrent
+//Returns nil if successful; an error if not
+func (tc *TorrentControl) SetPiecesWanted(infohash string, wanted Bitset) error {
+	return nil
+}
+
+//Returns the pieces requested that we have on hand (and len()==0 array is perfectly
+//acceptable, and expected if we don't have any of the pieces requested;
+//An error is returned if there's something wrong with the request.
+//(bad infohash; wanted bitset is the wrong length, etc.)
+func (tc *TorrentControl) GetPieces(infohash string, wanted Bitset) ([]chunk, error) {
+	return nil, nil
+}
+
+//Adds pieces to the specified torrent.
+//Might seem kinda strange, but it's useful if we're using other transfer
+//mechanisms besides/instead of the bittorrent protocol.
+func (tc *TorrentControl) SendPieces(infohash string, pieces []chunk) error {
+	return nil
+}
+
+func (tc *TorrentControl) ResumeTorrent(infohash string) error {
+	return nil
+}
+
+func (tc *TorrentControl) PauseTorrent(infohash string) error {
+	return nil
+}
+
+func (tc *TorrentControl) StopTorrent(infohash string) error {
+	return nil
+}
+
+func (tc *TorrentControl) RemoveTorrent(infohash string) error {
+	return nil
+}

--- a/torrent/torrentControl.go
+++ b/torrent/torrentControl.go
@@ -3,15 +3,18 @@ package torrent
 
 import (
 	"errors"
+	"log"
 	"strconv"
 )
 
 type TorrentManager interface {
-	Start() error
+	Start(tc *TorrentControl) error
 }
 
 type TorrentControl struct {
+	Flags           *TorrentFlags
 	TorrentSessions map[string]*TorrentSession
+	doneChan        chan<- *TorrentSession
 }
 
 //Add a torrent, by magnet uri, http link, or filepath.
@@ -20,19 +23,42 @@ type TorrentControl struct {
 //are fetched immediately for their tasty tasty metadata.
 //Returns the resulting infohash if successful; "" and an error if not
 func (tc *TorrentControl) AddTorrent(torr string, start bool) (string, error) {
-	return "", nil
+	var ts *TorrentSession
+	ts, err := NewTorrentSession(tc.Flags, torr, uint16(tc.Flags.Port))
+	if err != nil {
+		log.Println("Could not create torrent session.", err)
+		return "", err
+	}
+	log.Printf("Creating torrent session for %x", ts.M.InfoHash)
+	tc.TorrentSessions[ts.M.InfoHash] = ts
+	go func(ts *TorrentSession) {
+		ts.DoTorrent()
+		tc.doneChan <- ts
+	}(ts)
+	return "", errors.New("Not implemented yet.")
 }
 
 //Returns a copy of the metadata for a particular torrent if successful;
 //an zero-struct and error if not
 func (tc *TorrentControl) GetMetaData(infohash string) (MetaInfo, error) {
-	return MetaInfo{}, nil
+	ts, ok := tc.TorrentSessions[infohash]
+	if !ok {
+		return MetaInfo{}, errors.New("Infohash not found.")
+	}
+
+	//TODO: Should probably make a new copy, just in case the manager wants to
+	// mangle this one for some unfathomable reason
+	return *ts.M, nil
 }
 
 //Returns the status of a particular torrent if successful;
 //nil and an error if not.
 //Also, if infohash == "", should return status info for Taipei-Torrent itself
 func (tc *TorrentControl) GetStatus(infohash string) (map[string]string, error) {
+	if infohash == "" {
+		return nil, errors.New("Not implemented yet.")
+	}
+
 	ts, ok := tc.TorrentSessions[infohash]
 	if !ok {
 		return nil, errors.New("Infohash not found.")
@@ -49,48 +75,91 @@ func (tc *TorrentControl) GetStatus(infohash string) (map[string]string, error) 
 
 //Returns an array of infostrings for all the torrents
 func (tc *TorrentControl) GetTorrentList() []string {
-	infoH := make([]string, 0, len(tc.TorrentSessions))
-
+	infoH := make([]string, len(tc.TorrentSessions))
+	i := 0
 	for key := range tc.TorrentSessions {
-		infoH = append(infoH, key)
+		infoH[i] = key
+		i++
 	}
-
 	return infoH
 }
 
 //Sets the pieces wanted for a particular torrent
 //Returns nil if successful; an error if not
 func (tc *TorrentControl) SetPiecesWanted(infohash string, wanted Bitset) error {
-	return nil
+	return errors.New("Not implemented yet.")
 }
 
 //Returns the pieces requested that we have on hand (and len()==0 array is perfectly
 //acceptable, and expected if we don't have any of the pieces requested;
-//An error is returned if there's something wrong with the request.
+//Nil and an error is returned if there's something wrong with the request.
 //(bad infohash; wanted bitset is the wrong length, etc.)
 func (tc *TorrentControl) GetPieces(infohash string, wanted Bitset) ([]chunk, error) {
-	return nil, nil
+	ts, ok := tc.TorrentSessions[infohash]
+	if !ok {
+		return nil, errors.New("Infohash not found.")
+	}
+
+	if wanted.Len() != ts.pieceSet.Len() {
+		return nil, errors.New("Wanted bitset is wrong length.")
+	}
+
+	returnPieces := make([]chunk, 0, 32)
+	for i := 0; i < wanted.Len(); i++ {
+		if wanted.IsSet(i) && ts.pieceSet.IsSet(i) {
+			globalOffset := int64(i) * ts.M.Info.PieceLength
+
+			c := chunk{data: make([]byte, ts.pieceLength(i))}
+			c.i = int64(i)
+			_, err := ts.fileStore.ReadAt(c.data, globalOffset)
+			if err != nil {
+				log.Println("Error reading from file store:", err)
+			} else {
+				returnPieces = append(returnPieces, c)
+			}
+		}
+	}
+
+	return returnPieces, nil
 }
 
 //Adds pieces to the specified torrent.
 //Might seem kinda strange, but it's useful if we're using other transfer
 //mechanisms besides/instead of the bittorrent protocol.
 func (tc *TorrentControl) SendPieces(infohash string, pieces []chunk) error {
+	ts, ok := tc.TorrentSessions[infohash]
+	if !ok {
+		return errors.New("Infohash not found.")
+	}
+
+	for _, piece := range pieces {
+		if !ts.pieceSet.IsSet(int(piece.i)) {
+			globalOffset := piece.i * ts.M.Info.PieceLength
+			_, err := ts.fileStore.WriteAt(piece.data, globalOffset)
+			if err != nil {
+				log.Println("Error writing to file store:", err)
+			}
+			if !ts.RecordPiece(uint32(piece.i), len(piece.data)) {
+				log.Println("Got a bad piece from manager:", piece.i)
+			}
+		}
+	}
+
 	return nil
 }
 
 func (tc *TorrentControl) ResumeTorrent(infohash string) error {
-	return nil
+	return errors.New("Not implemented yet.")
 }
 
 func (tc *TorrentControl) PauseTorrent(infohash string) error {
-	return nil
+	return errors.New("Not implemented yet.")
 }
 
 func (tc *TorrentControl) StopTorrent(infohash string) error {
-	return nil
+	return errors.New("Not implemented yet.")
 }
 
 func (tc *TorrentControl) RemoveTorrent(infohash string) error {
-	return nil
+	return errors.New("Not implemented yet.")
 }

--- a/torrent/torrentLoop.go
+++ b/torrent/torrentLoop.go
@@ -29,7 +29,7 @@ type TorrentFlags struct {
 }
 
 func RunTorrents(flags *TorrentFlags, torrentFiles []string, managers []TorrentManager) (err error) {
-	conChan, listenPort, err := ListenForPeerConnections(flags)
+	conChan, listenPort, nat, err := ListenForPeerConnections(flags)
 	if err != nil {
 		log.Println("Couldn't listen for peers connection: ", err)
 		return
@@ -63,7 +63,7 @@ func RunTorrents(flags *TorrentFlags, torrentFiles []string, managers []TorrentM
 		lpd = startLPD(torrentSessions, uint16(listenPort))
 	}
 
-	torrentControl := TorrentControl{flags, torrentSessions, doneChan}
+	torrentControl := TorrentControl{flags, nat, torrentSessions, doneChan}
 	for _, manager := range managers {
 		manager.Start(&torrentControl)
 	}

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -419,12 +419,7 @@ func testHelperProcessImp(args []string) (err error) {
 			FileDir:   fileDir,
 			SeedRatio: seedRatio,
 		}
-		var torrentSessions map[string]*torrent.TorrentSession
-		torrentSessions = torrent.GetSessions(&torrentFlags, torrentFiles)
-		if err != nil {
-			return
-		}
-		err = torrent.RunTorrents(&torrentFlags, torrentSessions)
+		err = torrent.RunTorrents(&torrentFlags, torrentFiles, []TorrentManager{})
 		if err != nil {
 			return
 		}

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -419,7 +419,7 @@ func testHelperProcessImp(args []string) (err error) {
 			FileDir:   fileDir,
 			SeedRatio: seedRatio,
 		}
-		err = torrent.RunTorrents(&torrentFlags, torrentFiles, []TorrentManager{})
+		err = torrent.RunTorrents(&torrentFlags, torrentFiles, []torrent.TorrentManager{})
 		if err != nil {
 			return
 		}

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -419,7 +419,12 @@ func testHelperProcessImp(args []string) (err error) {
 			FileDir:   fileDir,
 			SeedRatio: seedRatio,
 		}
-		err = torrent.RunTorrents(&torrentFlags, torrentFiles)
+		var torrentSessions map[string]*torrent.TorrentSession
+		torrentSessions = torrent.GetSessions(&torrentFlags, torrentFiles)
+		if err != nil {
+			return
+		}
+		err = torrent.RunTorrents(&torrentFlags, torrentSessions)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Fair warning; this is just a proof of concept I'd been thinking about for a bit, and then decided to try when I discovered gowut (Go Web UI Toolkit) earlier this afternoon. 

Basically, I've added a struct/API (TorrentControl) for the use of  "Torrent Managers" that might be embedded into Taipei-Torrent. Examples of possible managers include a native gui, a webgui, a seedbox remote-control, etc. For now, TorrentControl is almost completely unimplemented, but as an example I've included a toy webgui (super-simple, extremely ugly) that uses it to list the currently running torrents and their percentage of completion (updated every 1 second).

Obviously this is nowhere near ready to merge, but I thought I'd bring it up to get some feedback/suggestions on the idea, and just in case there's a huge fatal flaw in the design that I'm not seeing.

Best Regards.