### PR TITLE
Add feature to create torrent file with tracker url

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 	flag.Parse()
 
 	if *createTorrent != "" {
-		err := torrent.WriteMetaInfoBytes(*createTorrent, os.Stdout)
+		err := torrent.WriteMetaInfoBytes(*createTorrent, *createTracker, os.Stdout)
 		if err != nil {
 			log.Fatal("Could not create torrent file:", err)
 		}

--- a/torrent/metainfo.go
+++ b/torrent/metainfo.go
@@ -231,7 +231,7 @@ func (f *FileStoreFileAdapter) Close() (err error) {
 // Create a MetaInfo for a given file and file system.
 // If fs is nil then the OSMetaInfoFileSystem will be used.
 // If pieceLength is 0 then an optimal piece length will be chosen.
-func CreateMetaInfoFromFileSystem(fs MetaInfoFileSystem, root string, pieceLength int64, wantMD5Sum bool) (metaInfo *MetaInfo, err error) {
+func CreateMetaInfoFromFileSystem(fs MetaInfoFileSystem, root, tracker string, pieceLength int64, wantMD5Sum bool) (metaInfo *MetaInfo, err error) {
 	if fs == nil {
 		dir, file := path.Split(root)
 		fs = &OSMetaInfoFileSystem{dir}
@@ -294,6 +294,9 @@ func CreateMetaInfoFromFileSystem(fs MetaInfoFileSystem, root string, pieceLengt
 	}
 	m.Info.Pieces = string(sums)
 	m.UpdateInfoHash(metaInfo)
+	if tracker != "" {
+		m.Announce = "http://" + tracker + "/announce"
+	}
 	metaInfo = m
 	return
 }
@@ -331,9 +334,9 @@ func roundUpToPowerOfTwo(v uint64) uint64 {
 	return v
 }
 
-func WriteMetaInfoBytes(root string, w io.Writer) (err error) {
+func WriteMetaInfoBytes(root, tracker string, w io.Writer) (err error) {
 	var m *MetaInfo
-	m, err = CreateMetaInfoFromFileSystem(nil, root, 0, true)
+	m, err = CreateMetaInfoFromFileSystem(nil, root, tracker, 0, true)
 	if err != nil {
 		return
 	}

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -198,11 +198,10 @@ func newTorrentClient(name string, port int, torrentFile string, fileDir string,
 
 func createTorrentFile(torrentFileName, root, announcePath string) (err error) {
 	var metaInfo *torrent.MetaInfo
-	metaInfo, err = torrent.CreateMetaInfoFromFileSystem(nil, root, 0, false)
+    metaInfo, err = torrent.CreateMetaInfoFromFileSystem(nil, root, "127.0.0.1:8080", 0, false)
 	if err != nil {
 		return
 	}
-	metaInfo.Announce = "http://127.0.0.1:8080/announce"
 	metaInfo.CreatedBy = "testSwarm"
 	var torrentFile *os.File
 	torrentFile, err = os.Create(torrentFileName)


### PR DESCRIPTION
This allows to specify the tracker url in the torrent file when using "-createTorrent".

E.g.:
./Taipei-Torrent -createTracker=127.17.0.2:8080 -createTorrent="/tmp/hello"

Will create a torrent file with "http://127.17.0.2:8080/announce" as the tracker url.