### PR TITLE
Download to SFTP; Skip initial check; Cache to ram or local disk

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,8 @@ var (
 	proxyAddress        = flag.String("proxyAddress", "", "Address of a SOCKS5 proxy to use.")
 	initialCheck        = flag.Bool("initialCheck", true, "Do an initial hash check on files when adding torrents")
 	useSFTP             = flag.String("useSFTP", "", "SFTP connection string, to store torrents over SFTP. e.g. 'username:password@192.168.1.25:22/path/'")
-	useRamCache         = flag.Int("useRamCache", 0, "Size in MiB of cache in ram, to reduce reads on torrent storage.")
+	useRamCache         = flag.Int("useRamCache", 0, "Size in MiB of cache in ram, to reduce traffic on torrent storage.")
+	useHdCache          = flag.Int("useHdCache", 0, "Size in MiB of cache in OS temp directory, to reduce traffic on torrent storage.")
 )
 
 func parseTorrentFlags() *torrent.TorrentFlags {
@@ -57,8 +58,16 @@ func parseTorrentFlags() *torrent.TorrentFlags {
 }
 
 func cacheproviderFromFlags() torrent.CacheProvider {
+	if (*useRamCache) > 0 && (*useHdCache) > 0 {
+		log.Panicln("Only one cache at a time, please.")
+	}
+
 	if (*useRamCache) > 0 {
 		return torrent.NewRamCacheProvider(*useRamCache)
+	}
+
+	if (*useHdCache) > 0 {
+		return torrent.NewHdCacheProvider(*useHdCache)
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"runtime/pprof"
 
-	socks "github.com/hailiang/gosocks"
+	"github.com/hailiang/socks"
 	"github.com/jackpal/Taipei-Torrent/torrent"
 	"github.com/jackpal/Taipei-Torrent/tracker"
 )
@@ -31,6 +31,9 @@ var (
 	useDHT              = flag.Bool("useDHT", false, "Use DHT to get peers.")
 	trackerlessMode     = flag.Bool("trackerlessMode", false, "Do not get peers from the tracker. Good for testing DHT mode.")
 	proxyAddress        = flag.String("proxyAddress", "", "Address of a SOCKS5 proxy to use.")
+	initialCheck        = flag.Bool("initialCheck", true, "Do an initial hash check on files when adding torrents")
+	useSFTP             = flag.String("useSFTP", "", "SFTP connection string, to store torrents over SFTP. e.g. 'username:password@192.168.1.25:22/path/'")
+	useRamCache         = flag.Int("useRamCache", 0, "Size in MiB of cache in ram, to reduce reads on torrent storage.")
 )
 
 func parseTorrentFlags() *torrent.TorrentFlags {
@@ -46,8 +49,25 @@ func parseTorrentFlags() *torrent.TorrentFlags {
 		UseNATPMP:           *useNATPMP,
 		TrackerlessMode:     *trackerlessMode,
 		// IP address of gateway
-		Gateway: *gateway,
+		Gateway:            *gateway,
+		InitialCheck:       *initialCheck,
+		FileSystemProvider: fsproviderFromFlags(),
+		Cacher:             cacheproviderFromFlags(),
 	}
+}
+
+func cacheproviderFromFlags() torrent.CacheProvider {
+	if (*useRamCache) > 0 {
+		return torrent.NewRamCacheProvider(*useRamCache)
+	}
+	return nil
+}
+
+func fsproviderFromFlags() torrent.FsProvider {
+	if len(*useSFTP) > 0 {
+		return torrent.NewSftpFsProvider(*useSFTP)
+	}
+	return torrent.OsFsProvider{}
 }
 
 func dialerFromFlags() torrent.Dialer {

--- a/torrent/cache.go
+++ b/torrent/cache.go
@@ -1,0 +1,200 @@
+// cache
+package torrent
+
+import (
+	"log"
+	"sort"
+	"time"
+)
+
+type CacheProvider interface {
+	NewCache(infohash string, capacity int64) TorrentCache
+}
+
+const RAMCHUNKS = 1024 * 1024
+
+type TorrentCache interface {
+	//Read what's cached, returns parts that weren't available to read.
+	ReadAt(p []byte, off int64) []chunk
+	//Writes to cache. No guarantee that it'll be here later.
+	WriteAt(p []byte, off int64)
+}
+
+//This simple provider creates a ram cache for each torrent.
+//Each cache has size capacity (in MiB).
+type RamCacheProvider struct {
+	capacity int
+}
+
+func NewRamCacheProvider(capacity int) CacheProvider {
+	rc := &RamCacheProvider{capacity}
+	return rc
+}
+
+func (r *RamCacheProvider) NewCache(infohash string, torrentLength int64) TorrentCache {
+	mib := int64(RAMCHUNKS)
+	boxes := int(torrentLength / mib)
+	if torrentLength%mib > 0 {
+		boxes++
+	}
+	rc := &RamCache{r.capacity, 0, torrentLength, make([][]byte, boxes), make([]time.Time, boxes), *NewBitset(boxes), make([]Bitset, boxes)}
+	return rc
+}
+
+//'maxCapacity' is how large in MiB the cache can grow
+//'actualUsage' is how large in MiB the cache is at the moment
+//'torrentLength' is the size in bytes of the whole torrent
+//'store' is an array of "boxes" ([]byte of 1 MiB each)
+//'atime' is an array of access times for each stored box
+//'isSetBitSet
+type RamCache struct {
+	maxCapacity   int
+	actualUsage   int
+	torrentLength int64
+	store         [][]byte
+	atimes        []time.Time
+	isBoxFull     Bitset
+	isByteSet     []Bitset
+}
+
+type int64arr []int64
+
+func (a int64arr) Len() int           { return len(a) }
+func (a int64arr) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a int64arr) Less(i, j int) bool { return a[i] < a[j] }
+
+func (r *RamCache) ReadAt(p []byte, off int64) []chunk {
+	unfulfilled := make([]chunk, 0)
+
+	boxI := int(off / int64(RAMCHUNKS))
+	boxOff := int(off % int64(RAMCHUNKS))
+
+	for i := 0; i < len(p); {
+		if r.store[boxI] == nil { //definitely not in cache
+			end := len(p[i:])
+			if end > RAMCHUNKS-boxOff {
+				end = RAMCHUNKS - boxOff
+			}
+			if len(unfulfilled) > 0 {
+				last := unfulfilled[len(unfulfilled)-1]
+				if last.i+int64(len(last.data)) == off+int64(i) {
+					unfulfilled = unfulfilled[:len(unfulfilled)-1]
+					i = int(last.i - off)
+					end += len(last.data)
+				}
+			}
+			unfulfilled = append(unfulfilled, chunk{off + int64(i), p[i : i+end]})
+			i += end
+		} else if r.isBoxFull.IsSet(boxI) { //definitely in cache
+			i += copy(p[i:], r.store[boxI][boxOff:])
+		} else { //Bah, do it byte by byte.
+			missing := []*inttuple{&inttuple{-1, -1}}
+			end := len(p[i:]) + boxOff
+			if end > RAMCHUNKS {
+				end = RAMCHUNKS
+			}
+			for j := boxOff; j < end; j++ {
+				if r.isByteSet[boxI].IsSet(j) {
+					p[i] = r.store[boxI][j]
+				} else {
+					lastIT := missing[len(missing)-1]
+					if lastIT.b == i {
+						lastIT.b = i + 1
+					} else {
+						missing = append(missing, &inttuple{i, i + 1})
+					}
+				}
+				i++
+			}
+			for _, intt := range missing[1:] {
+				unfulfilled = append(unfulfilled, chunk{off + int64(intt.a), p[intt.a:intt.b]})
+			}
+		}
+		boxI++
+		boxOff = 0
+	}
+	return unfulfilled
+}
+
+type inttuple struct {
+	a, b int
+}
+
+func (r *RamCache) WriteAt(p []byte, off int64) {
+	boxI := int(off / int64(RAMCHUNKS))
+	boxOff := int(off % int64(RAMCHUNKS))
+
+	for i := 0; i < len(p); {
+		if r.store[boxI] == nil {
+			r.store[boxI] = make([]byte, RAMCHUNKS)
+			r.actualUsage++
+		}
+		copied := copy(r.store[boxI][boxOff:], p[i:])
+		r.atimes[boxI] = time.Now()
+		if copied == RAMCHUNKS {
+			r.isBoxFull.Set(boxI)
+		} else {
+			if r.isByteSet[boxI].n == 0 {
+				r.isByteSet[boxI] = *NewBitset(RAMCHUNKS)
+			}
+			for j := boxOff; j < boxOff+copied; j++ {
+				r.isByteSet[boxI].Set(j)
+			}
+		}
+		i += copied
+		boxI++
+		boxOff = 0
+	}
+	if r.actualUsage > r.maxCapacity {
+		r.trim()
+	}
+}
+
+type accessTime struct {
+	index int
+	atime time.Time
+}
+type byTime []accessTime
+
+func (a byTime) Len() int           { return len(a) }
+func (a byTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byTime) Less(i, j int) bool { return a[i].atime.Before(a[j].atime) }
+
+//Trim excess data
+func (r *RamCache) trim() {
+	tATA := make([]accessTime, 0, r.actualUsage)
+
+	for i, atime := range r.atimes {
+		if r.store[i] != nil {
+			tATA = append(tATA, accessTime{i, atime})
+		}
+	}
+
+	sort.Sort(byTime(tATA))
+
+	deficit := r.actualUsage - r.maxCapacity
+	for i := 0; i < deficit; i++ {
+		deadBox := tATA[i].index
+		r.store[deadBox] = nil
+		r.isBoxFull.Clear(deadBox)
+		r.isByteSet[deadBox] = *NewBitset(0)
+		r.actualUsage--
+	}
+}
+
+func Dump(buff []byte) {
+	log.Println("Dumping []byte len=", len(buff))
+	for i := 0; i < len(buff); i += 16 {
+		skipLine := true
+		for j := i; j < len(buff) && j < 16+i; j++ {
+			if buff[j] != 0 {
+				skipLine = false
+				break
+			}
+		}
+		if !skipLine {
+			log.Printf("%X: %X\n", i, buff[i:i+16])
+		}
+	}
+	log.Println("Done Dumping")
+}

--- a/torrent/cache_test.go
+++ b/torrent/cache_test.go
@@ -1,0 +1,41 @@
+package torrent
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"io/ioutil"
+	"log"
+	"testing"
+)
+
+func TestCachedFileStoreRead(t *testing.T) {
+	rcp := NewRamCacheProvider(2000)
+	for _, testFile := range tests {
+		fs, err := mkFileStore(testFile)
+		orig, _ := ioutil.ReadFile(testFile.path)
+		tC := rcp.NewCache("", 20000)
+		tC.WriteAt(orig[128:512], 128)
+		fs.SetCache(tC)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ret := make([]byte, testFile.fileLen)
+		_, err = fs.ReadAt(ret, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantedsum := sha1.Sum(orig[:testFile.fileLen])
+		sum1Str := hex.EncodeToString(wantedsum[0:])
+		gotsum := sha1.Sum(ret)
+		sum2Str := hex.EncodeToString(gotsum[0:])
+		if sum1Str != sum2Str {
+			t.Errorf("Wanted %v, got %v\n", sum1Str, sum2Str)
+			for i := 0; i < len(ret); i++ {
+				if ret[i] != orig[i] {
+					log.Println("Found a difference at", i, "wanted", orig[i], "got", ret[i])
+					break
+				}
+			}
+		}
+	}
+}

--- a/torrent/files.go
+++ b/torrent/files.go
@@ -3,6 +3,7 @@ package torrent
 import (
 	"errors"
 	"io"
+	"log"
 )
 
 // Interface for a file.
@@ -11,6 +12,11 @@ type File interface {
 	io.ReaderAt
 	io.WriterAt
 	io.Closer
+}
+
+//Interface for a provider of filesystems.
+type FsProvider interface {
+	NewFS(directory string) (FileSystem, error)
 }
 
 // Interface for a file system. A file system contains files.
@@ -23,12 +29,14 @@ type FileStore interface {
 	io.ReaderAt
 	io.WriterAt
 	io.Closer
+	SetCache(TorrentCache)
 }
 
 type fileStore struct {
 	fileSystem FileSystem
 	offsets    []int64
 	files      []fileEntry // Stored in increasing globalOffset order
+	cache      TorrentCache
 }
 
 type fileEntry struct {
@@ -67,6 +75,10 @@ func NewFileStore(info *InfoDict, fileSystem FileSystem) (f FileStore, totalSize
 	return
 }
 
+func (f *fileStore) SetCache(cache TorrentCache) {
+	f.cache = cache
+}
+
 func (f *fileStore) find(offset int64) int {
 	// Binary search
 	offsets := f.offsets
@@ -84,7 +96,25 @@ func (f *fileStore) find(offset int64) int {
 	return low
 }
 
-func (f *fileStore) ReadAt(p []byte, off int64) (n int, err error) {
+func (f *fileStore) ReadAt(p []byte, off int64) (int, error) {
+	if f.cache == nil {
+		return f.RawReadAt(p, off)
+	}
+
+	unfullfilled := f.cache.ReadAt(p, off)
+
+	var retErr error
+	for _, unf := range unfullfilled {
+		_, err := f.RawReadAt(unf.data, unf.i)
+		if err != nil {
+			log.Println("Got an error on read (off=", unf.i, "len=", len(unf.data), ") from filestore:", err)
+			retErr = err
+		}
+	}
+	return len(p), retErr
+}
+
+func (f *fileStore) RawReadAt(p []byte, off int64) (n int, err error) {
 	index := f.find(off)
 	for len(p) > 0 && index < len(f.offsets) {
 		chunk := int64(len(p))
@@ -114,7 +144,15 @@ func (f *fileStore) ReadAt(p []byte, off int64) (n int, err error) {
 	return
 }
 
-func (f *fileStore) WriteAt(p []byte, off int64) (n int, err error) {
+func (f *fileStore) WriteAt(p []byte, off int64) (int, error) {
+	if f.cache != nil {
+		f.cache.WriteAt(p, off)
+	}
+
+	return f.RawWriteAt(p, off)
+}
+
+func (f *fileStore) RawWriteAt(p []byte, off int64) (n int, err error) {
 	index := f.find(off)
 	for len(p) > 0 && index < len(f.offsets) {
 		chunk := int64(len(p))

--- a/torrent/hdcache.go
+++ b/torrent/hdcache.go
@@ -1,0 +1,280 @@
+// hdcache
+package torrent
+
+import (
+	"encoding/hex"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"time"
+)
+
+//This simple provider creates an HD cache for each torrent.
+//Each cache has size capacity (in MiB).
+type HdCacheProvider struct {
+	capacity int
+}
+
+func NewHdCacheProvider(capacity int) CacheProvider {
+	os.Mkdir(filepath.FromSlash(os.TempDir()+"/taipeitorrent"), 0777)
+	rc := &HdCacheProvider{capacity}
+	return rc
+}
+
+func (r *HdCacheProvider) NewCache(infohash string, numPieces int, pieceSize int, torrentLength int64) TorrentCache {
+	maxNumPieces := (int64(r.capacity) * 1024 * 1024) / int64(pieceSize)
+	rc := &HdCache{pieceSize, int(maxNumPieces), 0, make([]time.Time, numPieces), *NewBitset(numPieces),
+		*NewBitset(numPieces), *NewBitset(numPieces), make([]Bitset, numPieces),
+		filepath.FromSlash(os.TempDir() + "/taipeitorrent/" + hex.EncodeToString([]byte(infohash)) + "-")}
+	rc.empty() //clear out any detritus from previous runs
+	return rc
+}
+
+//'pieceSize' is the size of the average piece
+//'maxCapacity' is how many pieces the cache can hold
+//'actualUsage' is how many pieces the cache has at the moment
+//'atime' is an array of access times for each stored box
+//'boxExists' indicates if a box is existent in cache
+//'isBoxFull' indicates if a box entirely contains written data
+//'isBoxCommit' indicates if a box has been committed to storage
+//'isByteSet' for [i] indicates for box 'i' if a byte has been written to
+//'boxPrefix' is the partial path to the boxes.
+type HdCache struct {
+	pieceSize   int
+	maxCapacity int
+	actualUsage int
+	atimes      []time.Time
+	boxExists   Bitset
+	isBoxFull   Bitset
+	isBoxCommit Bitset
+	isByteSet   []Bitset
+	boxPrefix   string
+}
+
+func (r *HdCache) Close() {
+	r.empty()
+}
+
+func (r *HdCache) empty() {
+	for i := 0; i < r.boxExists.Len(); i++ {
+		os.Remove(r.boxPrefix + strconv.Itoa(i))
+	}
+}
+
+func (r *HdCache) ReadAt(p []byte, off int64) []chunk {
+	unfulfilled := make([]chunk, 0)
+
+	boxI := int(off / int64(r.pieceSize))
+	boxOff := int(off % int64(r.pieceSize))
+
+	for i := 0; i < len(p); {
+		if !r.boxExists.IsSet(boxI) { //definitely not in cache
+			end := len(p[i:])
+			if end > r.pieceSize-boxOff {
+				end = r.pieceSize - boxOff
+			}
+			if len(unfulfilled) > 0 {
+				last := unfulfilled[len(unfulfilled)-1]
+				if last.i+int64(len(last.data)) == off+int64(i) {
+					unfulfilled = unfulfilled[:len(unfulfilled)-1]
+					i = int(last.i - off)
+					end += len(last.data)
+				}
+			}
+			unfulfilled = append(unfulfilled, chunk{off + int64(i), p[i : i+end]})
+			i += end
+		} else if r.isBoxFull.IsSet(boxI) { //definitely in cache
+			box, err := os.Open(r.boxPrefix + strconv.Itoa(boxI))
+			if err != nil {
+				log.Println("Error opening cache item we thought we had:", r.boxPrefix+strconv.Itoa(boxI), "error:", err)
+				r.removeBox(boxI)
+				continue //loop around without incrementing 'i', forget this ever happened
+			}
+
+			copied, err := box.ReadAt(p[i:], int64(boxOff))
+			box.Close()
+			i += copied
+
+			if err != nil && err != io.EOF {
+				log.Println("Error while reading cache item:", r.boxPrefix+strconv.Itoa(boxI), "error:", err)
+				r.removeBox(boxI)
+				continue //loop around without incrementing 'i', forget this ever happened
+			}
+		} else { //Bah, do it byte by byte.
+			missing := []*inttuple{&inttuple{-1, -1}}
+			end := len(p[i:]) + boxOff
+			if end > r.pieceSize {
+				end = r.pieceSize
+			}
+
+			box, err := ioutil.ReadFile(r.boxPrefix + strconv.Itoa(boxI))
+			if err != nil {
+				log.Println("Error reading cache item we thought we had:", r.boxPrefix+strconv.Itoa(boxI), "error:", err)
+				r.removeBox(boxI)
+				continue //loop around without incrementing 'i', forget this ever happened
+			}
+
+			for j := boxOff; j < end; j++ {
+				if r.isByteSet[boxI].IsSet(j) {
+					p[i] = box[j]
+				} else {
+					lastIT := missing[len(missing)-1]
+					if lastIT.b == i {
+						lastIT.b = i + 1
+					} else {
+						missing = append(missing, &inttuple{i, i + 1})
+					}
+				}
+				i++
+			}
+			for _, intt := range missing[1:] {
+				unfulfilled = append(unfulfilled, chunk{off + int64(intt.a), p[intt.a:intt.b]})
+			}
+		}
+		boxI++
+		boxOff = 0
+	}
+	return unfulfilled
+}
+
+func (r *HdCache) WriteAt(p []byte, off int64) []chunk {
+	boxI := int(off / int64(r.pieceSize))
+	boxOff := int(off % int64(r.pieceSize))
+
+	for i := 0; i < len(p); {
+		var box *os.File
+		var err error
+		if !r.boxExists.IsSet(boxI) { //box doesn't exist, so we'll make one.
+			box, err = os.Create(r.boxPrefix + strconv.Itoa(boxI))
+			if err != nil {
+				log.Panicln("Couldn't create cache file:", err)
+				return nil
+			}
+			r.boxExists.Set(boxI)
+			box.Truncate(int64(r.pieceSize))
+			r.actualUsage++
+		} else { //box exists, so we'll open it
+			box, err = os.OpenFile(r.boxPrefix+strconv.Itoa(boxI), os.O_WRONLY, 0777)
+			if err != nil {
+				log.Println("Error opening cache item we thought we had:", r.boxPrefix+strconv.Itoa(boxI), "error:", err)
+				r.removeBox(boxI)
+				continue //loop around without incrementing 'i', forget this ever happened
+			}
+		}
+		end := r.pieceSize - boxOff
+		if len(p) < end {
+			end = len(p)
+		}
+		copied, err := box.WriteAt(p[i:end], int64(boxOff))
+		if err != nil {
+			log.Panicln("Error at write cache box:", box.Name(), "error:", err)
+		}
+		i += copied
+		box.Close()
+		r.atimes[boxI] = time.Now()
+		if copied == r.pieceSize {
+			r.isBoxFull.Set(boxI)
+		} else {
+			if r.isByteSet[boxI].n == 0 {
+				r.isByteSet[boxI] = *NewBitset(r.pieceSize)
+			}
+			for j := boxOff; j < boxOff+copied; j++ {
+				r.isByteSet[boxI].Set(j)
+			}
+		}
+		boxI++
+		boxOff = 0
+	}
+	if r.actualUsage > r.maxCapacity {
+		return r.trim()
+	}
+	return nil
+}
+
+func (r *HdCache) MarkCommitted(piece int) {
+	if r.boxExists.IsSet(piece) {
+		r.isBoxFull.Set(piece)
+		r.isBoxCommit.Set(piece)
+		r.isByteSet[piece] = *NewBitset(0)
+	}
+}
+
+func (r *HdCache) removeBox(boxI int) {
+	r.isBoxFull.Clear(boxI)
+	r.boxExists.Clear(boxI)
+	r.isBoxCommit.Clear(boxI)
+	r.isByteSet[boxI] = *NewBitset(0)
+	err := os.Remove(r.boxPrefix + strconv.Itoa(boxI))
+	if err != nil {
+		log.Println("Error removing cache box:", err)
+	} else {
+		r.actualUsage--
+	}
+}
+
+//Trim excess data. Returns any uncommitted chunks that were trimmed
+func (r *HdCache) trim() []chunk {
+	//Trim stuff that's already been committed first
+	for i := 0; i < r.isBoxCommit.Len(); i++ {
+		if r.isBoxCommit.IsSet(i) {
+			r.removeBox(i)
+		}
+		if r.actualUsage == r.maxCapacity {
+			return nil
+		}
+	}
+
+	retVal := make([]chunk, 0)
+
+	//Still need more space? figure out what's oldest
+	//RawWrite it to storage, and clear that then
+	tATA := make([]accessTime, 0, r.actualUsage)
+
+	for i, atime := range r.atimes {
+		if r.boxExists.IsSet(i) {
+			tATA = append(tATA, accessTime{i, atime})
+		}
+	}
+
+	sort.Sort(byTime(tATA))
+
+	deficit := r.actualUsage - r.maxCapacity
+	for i := 0; i < deficit; i++ {
+		deadBox := tATA[i].index
+		data, err := ioutil.ReadFile(r.boxPrefix + strconv.Itoa(deadBox))
+		if err != nil {
+			log.Println("Error reading cache box for trimming:", err)
+		} else {
+			if r.isBoxFull.IsSet(deadBox) { //Easy, the whole box has to go
+				retVal = append(retVal, chunk{int64(deadBox) * int64(r.pieceSize), data})
+			} else { //Ugh, we'll just trim anything unused from the start and the end, and send that.
+				off := int64(0)
+				endData := r.pieceSize
+				//Trim out any unset bytes at the beginning
+				for j := 0; j < r.pieceSize; j++ {
+					if !r.isByteSet[deadBox].IsSet(j) {
+						off++
+					} else {
+						break
+					}
+				}
+
+				//Trim out any unset bytes at the end
+				for j := r.pieceSize - 1; j > 0; j-- {
+					if !r.isByteSet[deadBox].IsSet(j) {
+						endData--
+					} else {
+						break
+					}
+				}
+				retVal = append(retVal, chunk{int64(deadBox)*int64(r.pieceSize) + off, data[off:endData]})
+			}
+		}
+		r.removeBox(deadBox)
+	}
+	return retVal
+}

--- a/torrent/hdcache_test.go
+++ b/torrent/hdcache_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 )
 
-func TestCachedFileStoreRead(t *testing.T) {
-	rcp := NewRamCacheProvider(2000)
+func TestHDCachedFileStoreRead(t *testing.T) {
+	rcp := NewHdCacheProvider(2000)
 	for _, testFile := range tests {
 		fs, err := mkFileStore(testFile)
 		orig, _ := ioutil.ReadFile(testFile.path)

--- a/torrent/osfiles.go
+++ b/torrent/osfiles.go
@@ -17,7 +17,9 @@ type osFile struct {
 	filePath string
 }
 
-func NewOSFileSystem(directory string) (fs FileSystem, err error) {
+type OsFsProvider struct{}
+
+func (o OsFsProvider) NewFS(directory string) (fs FileSystem, err error) {
 	return &osFileSystem{directory}, nil
 }
 

--- a/torrent/peer.go
+++ b/torrent/peer.go
@@ -100,7 +100,7 @@ func NewPeerState(conn net.Conn) *peerState {
 }
 
 func (p *peerState) Close() {
-	log.Println("Closing connection to", p.address)
+	//log.Println("Closing connection to", p.address)
 	p.conn.Close()
 	// No need to close p.writeChan. Further writes to p.conn will just fail.
 }

--- a/torrent/pieces.go
+++ b/torrent/pieces.go
@@ -96,9 +96,10 @@ func hashPiece(h chan chunk, result chan chunk) {
 	}
 }
 
-func checkPiece(fs FileStore, totalLength int64, m *MetaInfo, pieceIndex int) (good bool, err error) {
+func checkPiece(fs FileStore, totalLength int64, m *MetaInfo, pieceIndex int) (good bool, err error, piece []byte) {
 	ref := m.Info.Pieces
-	currentSum, err := computePieceSum(fs, totalLength, m.Info.PieceLength, pieceIndex)
+	var currentSum []byte
+	currentSum, err, piece = computePieceSum(fs, totalLength, m.Info.PieceLength, pieceIndex)
 	if err != nil {
 		return
 	}
@@ -112,10 +113,10 @@ func checkPiece(fs FileStore, totalLength int64, m *MetaInfo, pieceIndex int) (g
 	return
 }
 
-func computePieceSum(fs FileStore, totalLength int64, pieceLength int64, pieceIndex int) (sum []byte, err error) {
+func computePieceSum(fs FileStore, totalLength int64, pieceLength int64, pieceIndex int) (sum []byte, err error, piece []byte) {
 	numPieces := (totalLength + pieceLength - 1) / pieceLength
 	hasher := sha1.New()
-	piece := make([]byte, pieceLength)
+	piece = make([]byte, pieceLength)
 	if int64(pieceIndex) == numPieces-1 {
 		piece = piece[0 : totalLength-int64(pieceIndex)*pieceLength]
 	}

--- a/torrent/ramfiles.go
+++ b/torrent/ramfiles.go
@@ -1,5 +1,11 @@
 package torrent
 
+type ramFsProvider struct{}
+
+func (o ramFsProvider) NewFS(directory string) (fs FileSystem, err error) {
+	return &ramFileSystem{}, nil
+}
+
 // A RAM file system.
 type ramFileSystem struct {
 }

--- a/torrent/sftp.go
+++ b/torrent/sftp.go
@@ -115,14 +115,8 @@ func (sfs *SftpFileSystem) Close() (err error) {
 }
 
 func (sfs *SftpFileSystem) ensureDirectory(fullPath string) error {
-	//The following is annoyingly necessary because:
-	// a) sftp doesn't have a MkdirAll
-	// b) path.Split() has issues with forward-slash vs. back-slash, when on windows vs. linux
+	fullPath = filepath.ToSlash(fullPath)
 	fullPath = pathpkg.Clean(fullPath)
-	fullPath = strings.Replace(fullPath, "\\", "/", -1)
-	for strings.Contains(fullPath, "//") {
-		fullPath = strings.Replace(fullPath, "//", "/", -1)
-	}
 	path := strings.Split(fullPath, "/")
 	path = path[:len(path)-1] //remove filename
 

--- a/torrent/sftp.go
+++ b/torrent/sftp.go
@@ -1,0 +1,164 @@
+package torrent
+
+import (
+	"errors"
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+	"log"
+	"net"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"strings"
+)
+
+type SftpFsProvider struct {
+	Server     string
+	Username   string
+	Password   string
+	ServerPath string
+}
+
+//Connection string:  username:password@example.com:8042/over/there/
+func NewSftpFsProvider(connection string) SftpFsProvider {
+	connSA := strings.Split(connection, "@")
+	authSA := strings.Split(connSA[0], ":")
+	serverSA := strings.SplitN(connSA[1], "/", 2)
+	path := "/"
+	if len(serverSA) == 2 { // {example.com:8042, over/there/}
+		path += serverSA[1]
+	}
+	sp := SftpFsProvider{
+		Username:   authSA[0],
+		Password:   authSA[1],
+		Server:     serverSA[0],
+		ServerPath: path,
+	}
+	return sp
+}
+
+func (o SftpFsProvider) NewFS(directory string) (fs FileSystem, err error) {
+	sftpfs := &SftpFileSystem{
+		sp:               o,
+		torrentDirectory: directory,
+		closed:           true,
+	}
+
+	return sftpfs, sftpfs.Connect()
+}
+
+type SftpFileSystem struct {
+	sp               SftpFsProvider
+	torrentDirectory string
+	sftpClient       *sftp.Client
+	sshClient        *ssh.Client
+	closed           bool //false normally, true if closed
+}
+
+func (sfs *SftpFileSystem) Connect() error {
+	var auths []ssh.AuthMethod
+	if aconn, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK")); err == nil {
+		auths = append(auths, ssh.PublicKeysCallback(agent.NewClient(aconn).Signers))
+	}
+	if len(sfs.sp.Password) != 0 {
+		auths = append(auths, ssh.Password(sfs.sp.Password))
+	}
+
+	config := ssh.ClientConfig{
+		User: sfs.sp.Username,
+		Auth: auths,
+	}
+	var err error
+	sfs.sshClient, err = ssh.Dial("tcp", sfs.sp.Server, &config)
+	if err != nil {
+		log.Println("unable to connect to [%s]: %v", sfs.sp.Server, err)
+		return err
+	}
+
+	sfs.sftpClient, err = sftp.NewClient(sfs.sshClient)
+	if err != nil {
+		log.Println("unable to start sftp subsytem: %v", err)
+		return err
+	}
+	return nil
+}
+
+func (sfs *SftpFileSystem) translate(name []string) string {
+	path := pathpkg.Clean(sfs.torrentDirectory + "/" + pathpkg.Join(name...))
+	return pathpkg.Clean(filepath.Join(sfs.sp.ServerPath, path))
+}
+
+func (sfs *SftpFileSystem) Open(name []string, length int64) (File, error) {
+	fullPath := sfs.translate(name)
+	err := sfs.ensureDirectory(fullPath)
+	if err != nil {
+		log.Println("Couldn't ensure directory:", fullPath)
+		return nil, err
+	}
+
+	file, err := sfs.sftpClient.OpenFile(fullPath, os.O_RDWR)
+	if err != nil {
+		file, err = sfs.sftpClient.Create(fullPath)
+		if err != nil {
+			log.Println("Couldn't create file:", fullPath, "error:", err)
+			return nil, err
+		}
+	}
+	retVal := &SftpFile{file}
+	err = file.Truncate(length)
+	return retVal, err
+}
+
+func (sfs *SftpFileSystem) Close() (err error) {
+	return
+}
+
+func (sfs *SftpFileSystem) ensureDirectory(fullPath string) error {
+	//The following is annoyingly necessary because:
+	// a) sftp doesn't have a MkdirAll
+	// b) path.Split() has issues with forward-slash vs. back-slash, when on windows vs. linux
+	fullPath = pathpkg.Clean(fullPath)
+	fullPath = strings.Replace(fullPath, "\\", "/", -1)
+	for strings.Contains(fullPath, "//") {
+		fullPath = strings.Replace(fullPath, "//", "/", -1)
+	}
+	path := strings.Split(fullPath, "/")
+	path = path[:len(path)-1] //remove filename
+
+	total := ""
+	for _, str := range path {
+		total += str + "/"
+		sfs.sftpClient.Mkdir(total)
+		//We're not too concerned with if Mkdir gave an error, since it could just be that the
+		//directory already exists. And if not, then the final Stat call will error out anyway.
+	}
+	fi, err := sfs.sftpClient.Lstat(total)
+	if err != nil {
+		return err
+	}
+
+	if fi.IsDir() {
+		return nil
+	}
+
+	return errors.New("Part of path isn't a directory! path=" + total)
+}
+
+type SftpFile struct {
+	file *sftp.File
+}
+
+func (sff *SftpFile) ReadAt(p []byte, off int64) (n int, err error) {
+	sff.file.Seek(off, os.SEEK_SET)
+	return sff.file.Read(p)
+}
+
+func (sff *SftpFile) WriteAt(p []byte, off int64) (n int, err error) {
+	sff.file.Seek(off, os.SEEK_SET)
+	return sff.file.Write(p)
+}
+
+func (sff *SftpFile) Close() error {
+	return sff.file.Close()
+}

--- a/torrent/torrentLoop.go
+++ b/torrent/torrentLoop.go
@@ -26,6 +26,15 @@ type TorrentFlags struct {
 
 	// IP address of gateway used for NAT-PMP
 	Gateway string
+
+	//Provides the filesystems added torrents are saved to
+	FileSystemProvider FsProvider
+
+	//Whether to check file hashes when adding torrents
+	InitialCheck bool
+
+	//Provides cache to each torrent
+	Cacher CacheProvider
 }
 
 func RunTorrents(flags *TorrentFlags, torrentFiles []string) (err error) {

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -418,6 +418,8 @@ func testHelperProcessImp(args []string) (err error) {
 			Port:      int(port),
 			FileDir:   fileDir,
 			SeedRatio: seedRatio,
+			FileSystemProvider: torrent.OsFsProvider{},
+			InitialCheck:       true,
 		}
 		err = torrent.RunTorrents(&torrentFlags, torrentFiles)
 		if err != nil {


### PR DESCRIPTION
The purpose of this code change is to permit Taipei-Torrent to save the
downloaded torrent to an SFTP server instead of the local filesystem.
The reason that this might be useful is that some machines (i.e. cheap
VPS's) don't have enough harddrive space to download large torrents (and
often can't be modified to include the FUSE kernel extensions necessary
for mounting SFTP shares). In order to make this feature relatively
efficient, it's useful to skip the initial hash check on load, as well
as to cache some of the data locally (otherwise you end up transferring
the data multiple times; once to write to file, and again each time it
checks the hash). So, a flag to prevent the initial hash check has been
added, as well as an interface type for caches. Also included is a pair of cache
implementations, one using ram and another using disk. I've tested this out on a
few torrents with a VPS across the pond, and have had no problems so far
(tmux has been useful for this). So, I'd categorize it as late alpha/early beta
quality code.

One might ask, what does this do that a Socks proxy doesn't? Well, for one peer
communication is faster since it's directly between the VPS and the peers. Also, it's
more efficient with bandwidth since a) bad pieces aren't transferred from the VPS
to the user, and b) pieces that are in cache can be shared directly from the VPS to
peers, instead of having to get them from the user first.