### PR TITLE
Quick fix: Close filestore and filesystem when shutting down.

### DIFF
--- a/torrent/cache.go
+++ b/torrent/cache.go
@@ -74,6 +74,7 @@ type RamCache struct {
 }
 
 func (r *RamCache) Close() {
+	//We don't need to do anything. The garbage collector will take care of it.
 }
 
 func (r *RamCache) ReadAt(p []byte, off int64) []chunk {

--- a/torrent/files.go
+++ b/torrent/files.go
@@ -22,6 +22,7 @@ type FsProvider interface {
 // Interface for a file system. A file system contains files.
 type FileSystem interface {
 	Open(name []string, length int64) (file File, err error)
+	io.Closer
 }
 
 // A torrent file store.
@@ -212,6 +213,9 @@ func (f *fileStore) Close() (err error) {
 	if f.cache != nil {
 		f.cache.Close()
 		f.cache = nil
+	}
+	if f.fileSystem != nil {
+	err = f.fileSystem.Close()
 	}
 	return
 }

--- a/torrent/metainfo.go
+++ b/torrent/metainfo.go
@@ -207,6 +207,10 @@ func (f *FileStoreFileSystemAdapter) Open(name []string, length int64) (file Fil
 	return
 }
 
+func (f *FileStoreFileSystemAdapter) Close() error {
+	return nil
+}
+
 func (f *FileStoreFileAdapter) ReadAt(p []byte, off int64) (n int, err error) {
 	return f.f.ReadAt(p, off)
 }

--- a/torrent/osfiles.go
+++ b/torrent/osfiles.go
@@ -38,6 +38,10 @@ func (o *osFileSystem) Open(name []string, length int64) (file File, err error) 
 	return
 }
 
+func (o *osFileSystem) Close() error {
+	return nil
+}
+
 func (o *osFile) Close() (err error) {
 	return
 }

--- a/torrent/ramfiles.go
+++ b/torrent/ramfiles.go
@@ -22,6 +22,10 @@ func (r *ramFileSystem) Open(name []string, length int64) (file File, err error)
 	return
 }
 
+func (r *ramFileSystem) Close() error {
+	return nil
+}
+
 func (r ramFile) ReadAt(p []byte, off int64) (n int, err error) {
 	n = copy(p, []byte(r)[off:])
 	return

--- a/torrent/sftp.go
+++ b/torrent/sftp.go
@@ -111,6 +111,12 @@ func (sfs *SftpFileSystem) Open(name []string, length int64) (File, error) {
 }
 
 func (sfs *SftpFileSystem) Close() (err error) {
+	sfs.closed = true
+	err = sfs.sftpClient.Close()
+	sfs.sshClient.Close()
+	if err != nil {
+		log.Println("Error closing sftp client:", err)
+	}
 	return
 }
 

--- a/torrent/torrent.go
+++ b/torrent/torrent.go
@@ -489,6 +489,10 @@ func (t *TorrentSession) Shutdown() (err error) {
 	if t.dht != nil {
 		t.dht.Stop()
 	}
+	err = t.fileStore.Close()
+	if err != nil {
+		log.Println("Error closing filestore for torrent", t.M.Info.Name, ":", err)
+	}
 	return
 }
 


### PR DESCRIPTION
So, apparently fileStore.Close(), despite existing previously, was never
actually called. In previous versions this had no ill effect, but now it
means that the cache isn't being cleared.

This commit adds a call for fileStore.Close()
to TorrentSession.Shutdown(). Thus it gets called if:
a) The torrent is done seeding
b) User input Ctrl-C

Also, investigating this bug led me to notice that the SFTP connection
wasn't being closed gracefully, so I've added io.Closer to the
FileSystem interface and added a call for it to fileStore.Close().