### PR TITLE
Add -execOnSeeding option argument

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var (
 	useSFTP             = flag.String("useSFTP", "", "SFTP connection string, to store torrents over SFTP. e.g. 'username:password@192.168.1.25:22/path/'")
 	useRamCache         = flag.Int("useRamCache", 0, "Size in MiB of cache in ram, to reduce traffic on torrent storage.")
 	useHdCache          = flag.Int("useHdCache", 0, "Size in MiB of cache in OS temp directory, to reduce traffic on torrent storage.")
+	execOnSeeding       = flag.String("execOnSeeding", "", "Command to execute when torrent has fully downloaded and has begun seeding.")
 )
 
 func parseTorrentFlags() *torrent.TorrentFlags {
@@ -54,6 +55,7 @@ func parseTorrentFlags() *torrent.TorrentFlags {
 		InitialCheck:       *initialCheck,
 		FileSystemProvider: fsproviderFromFlags(),
 		Cacher:             cacheproviderFromFlags(),
+		ExecOnSeeding:      *execOnSeeding,
 	}
 }
 

--- a/torrent/torrentLoop.go
+++ b/torrent/torrentLoop.go
@@ -20,6 +20,7 @@ type TorrentFlags struct {
 	UseUPnP             bool
 	UseNATPMP           bool
 	TrackerlessMode     bool
+	ExecOnSeeding       string
 
 	// The dial function to use. Nil means use net.Dial
 	Dial Dialer


### PR DESCRIPTION
Add a new command-line argument, -execOnSeeding, that takes a path to a
program that will be executed (without any command-line arguments) when
the active torrent has fully downloaded.

The program's environment will be populated with the following
environment variables:

- TORRENT_FILE: the path to the torrent file
- TORRENT_INFOHASH: the Infohash of the torrent file

Closes jackpal/Taipei-Torrent#86