### PR TITLE
expose TorrentSession.SessionInfo

### DIFF
--- a/torrent/proxy.go
+++ b/torrent/proxy.go
@@ -19,7 +19,7 @@ func proxyHttpGet(dialer proxy.Dialer, url string) (r *http.Response, e error) {
 
 func proxyHttpClient(dialer proxy.Dialer) (client *http.Client) {
 	if dialer == nil {
-		dialer = proxy.Direct;
+		dialer = proxy.Direct
 	}
 	tr := &http.Transport{Dial: dialer.Dial}
 	client = &http.Client{Transport: tr}

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -421,7 +421,7 @@ func testHelperProcessImp(args []string) (err error) {
 			InitialCheck:       true,
 			MaxActive:          1,
 			ExecOnSeeding:      "",
-			Cacher:				torrent.NewRamCacheProvider(1),
+			Cacher:             torrent.NewRamCacheProvider(1),
 		}
 		err = torrent.RunTorrents(&torrentFlags, torrentFiles)
 		if err != nil {


### PR DESCRIPTION
It is useful to be able to have access to a `TorrentSession`'s `SessionInfo`, so I've exported it. This really helps with embedding Taipei Torrent in another app, so you can introspect the current status of a session.