### PR TITLE
correctly handle listen port 0

### DIFF
--- a/torrent/listen.go
+++ b/torrent/listen.go
@@ -82,6 +82,11 @@ func CreateListener(flags *TorrentFlags) (listener net.Listener, externalPort in
 	if err != nil {
 		log.Fatal("Listen failed:", err)
 	}
+	if listenPort == 0 {
+		_, portString, _ := net.SplitHostPort(listener.Addr().String())
+		listenPort, _ = strconv.Atoi(portString)
+		flags.Port = listenPort
+	}
 	log.Println("Listening for peers on port:", listenPort)
 	externalPort = listenPort
 	return

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -131,7 +131,7 @@ func runSwarm(leechCount int) (err error) {
 	time.Sleep(100 * time.Microsecond)
 
 	var seed, leech *prog
-	seed = newTorrentClient("seed", 7000, torrentFile, seedDir, math.Inf(0))
+	seed = newTorrentClient("seed", 0, torrentFile, seedDir, math.Inf(0))
 	err = seed.start(doneCh)
 	if err != nil {
 		return
@@ -145,7 +145,7 @@ func runSwarm(leechCount int) (err error) {
 		if err != nil {
 			return
 		}
-		leech = newTorrentClient(fmt.Sprintf("leech %d", l), 7001+l, torrentFile, leechDir, 0)
+		leech = newTorrentClient(fmt.Sprintf("leech%d", l), 0, torrentFile, leechDir, 0)
 		err = leech.start(doneCh)
 		if err != nil {
 			return


### PR DESCRIPTION
when listen port is set to 0, `net.ListenTCP` correctly chooses an available port to listen to. In that case the `CreateListener` should update this value of 0 to the actual port chosen by net package, so it can correctly advertise itself to the tracker