### PR TITLE
avoid potential deadlocks in torrentLoop.go

### DIFF
--- a/torrent/torrentLoop.go
+++ b/torrent/torrentLoop.go
@@ -136,7 +136,7 @@ mainLoop:
 		case c := <-conChan:
 			log.Printf("New bt connection for ih %x", c.Infohash)
 			if ts, ok := torrentSessions[c.Infohash]; ok {
-				ts.AcceptNewPeer(c)
+				go ts.AcceptNewPeer(c)
 			}
 		case dhtPeers := <-dhtNode.PeersRequestResults:
 			for key, peers := range dhtPeers {
@@ -144,7 +144,7 @@ mainLoop:
 					log.Printf("Received %d DHT peers for torrent session %x\n", len(peers), []byte(key))
 					for _, peer := range peers {
 						peer = dht.DecodePeerAddress(peer)
-						ts.HintNewPeer(peer)
+						go ts.HintNewPeer(peer)
 					}
 				} else {
 					log.Printf("Received DHT peer for an unknown torrent session %x\n", []byte(key))
@@ -157,7 +157,7 @@ mainLoop:
 			}
 			if ts, ok := torrentSessions[string(hexhash)]; ok {
 				log.Printf("Received LPD announce for ih %s", announce.Infohash)
-				ts.HintNewPeer(announce.Peer)
+				go ts.HintNewPeer(announce.Peer)
 			}
 		}
 	}

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -42,8 +42,6 @@ func TestSwarm10(t *testing.T) {
 	testSwarm(t, 10)
 }
 
-/* Larger sizes don't work correctly.
-
 func TestSwarm20(t *testing.T) {
 	testSwarm(t, 20)
 }
@@ -55,8 +53,6 @@ func TestSwarm50(t *testing.T) {
 func TestSwarm100(t *testing.T) {
 	testSwarm(t, 100)
 }
-
-*/
 
 func testSwarm(t *testing.T, leechCount int) {
 	err := runSwarm(leechCount)


### PR DESCRIPTION
following #55, if RunTorrents (mainloop of torrentLoop.go), is run in the main routine (as it's the case with tracker_test or main), there are potential deadlocks between the mainloop and innerloop (torrent's DoTorrent). the mainloop tries to contact/accept a new peer through either ts.hintNewPeerChan or ts.addPeerChan, while the receiving innerloop has run its course (seedRatio met + have data), resulting in mainloop hanging on a send on channel.

Doing these operations in a goroutine seems to fix the issue, tests are welcome
