### PR TITLE
fixing error in generating random ID

### DIFF
--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -152,7 +152,7 @@ func randomString(s string, n int) string {
 	b := make([]byte, n)
 	slen := len(s)
 	for i := 0; i < n; i++ {
-		b[i] = b[rand.Intn(slen)]
+		b[i] = s[rand.Intn(slen)]
 	}
 	return string(b)
 }


### PR DESCRIPTION
Fixing error in generating random ID for struct Tracker. In  randomString function, in order to generate ID on the basis of a string "0123456789abcdef", the project should have liked to generate random char from string  "0123456789abcdef" and assigns it to b[i], but it actually assigns b[] to b[i]. It is a nil array.