### PR TITLE
fix problem in #105

### DIFF
--- a/torrent/torrent.go
+++ b/torrent/torrent.go
@@ -727,6 +727,8 @@ func (ts *TorrentSession) DoTorrent() {
 
 		case <-ts.quit:
 			log.Println("[", ts.M.Info.Name, "] Quitting torrent session")
+			ts.fetchTrackerInfo("stopped")
+			time.Sleep(10*time.Millisecond)
 			return
 		}
 	}


### PR DESCRIPTION
when the Taipei-Torrent client stops, it does not request the tracker to delete the peerID.