### PR TITLE
fixing error in closing peer

### DIFF
--- a/torrent/torrent.go
+++ b/torrent/torrent.go
@@ -670,8 +670,9 @@ func (ts *TorrentSession) DoTorrent() {
 			if err2 != nil {
 				if err2 != io.EOF {
 					log.Println("[", ts.M.Info.Name, "] Closing peer", peer.address, "because", err2)
+					ts.ClosePeer(peer)
 				}
-				ts.ClosePeer(peer)
+				
 			}
 		case <-heartbeatChan:
 			if ts.flags.UseDeadlockDetector {


### PR DESCRIPTION
Taipei-Torrent should close peer when err != io.EOF, otherwise, as in the original codes, it will close peer when err ==io.EOF. But this will happen every time when it can not receive a piece by  function "err = ts.RequestBlock2(p, k, false)". Because this function will return io.EOF when its peers do not have the pieces it needs. After closing, it can not download pieces from the peer because there is no connection between them anymore, even though the peer have the pieces it need again. I have tested this for one day to find the reasons that Taipei-Torrent can not receive pieces after it do not get piece one time and set to "UNINTERESTED" to the peer.  